### PR TITLE
Fix NameError on `typeprof --version`

### DIFF
--- a/lib/typeprof.rb
+++ b/lib/typeprof.rb
@@ -5,6 +5,7 @@ end
 
 module TypeProf end
 
+require_relative "typeprof/version"
 require_relative "typeprof/config"
 require_relative "typeprof/insns-def"
 require_relative "typeprof/utils"


### PR DESCRIPTION
When I run the command `typeprof --version`, the following error occurs:

```console
$ exe/typeprof --version
Traceback (most recent call last):
	1: from exe/typeprof:5:in `<main>'
/Users/masafumi.koba/git/ybiquitous/typeprof/lib/typeprof/cli.rb:78:in `parse': uninitialized constant TypeProf::CLI::VERSION (NameError)
```

This patch aims to fix the error. Here is an expectation:

```console
$ exe/typeprof --version
typeprof 0.3.0
```