### PR TITLE
Add link to typeprof-playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,6 @@ end
 
 ## Playground
 
-Accessing below URL, you can try to use typeprof gem on Web.
+You can try typeprof gem on the Web via the URL below.
 
 https://mame.github.io/typeprof-playground/

--- a/README.md
+++ b/README.md
@@ -33,3 +33,9 @@ end
 ## Documentation
 
 [English](doc/doc.md) / [日本語](doc/doc.ja.md)
+
+## Playground
+
+Accessing below URL, you can try to use typeprof gem on Web.
+
+https://mame.github.io/typeprof-playground/


### PR DESCRIPTION
I think that typeprof-playground is very exciting because we can try typeprof on the Web.
But I think that we are a little bit difficult to notice typeprof-playground without knowing its name.
e.g. Searching "typeprof ruby" on Google, `Ruby Typeprof Playground` ranking is 7th.
So I added the link to it into README.md.