### PR TITLE
Add more dependencies of standard libraries

### DIFF
--- a/lib/typeprof/import.rb
+++ b/lib/typeprof/import.rb
@@ -32,9 +32,17 @@ module TypeProf
       loader.add(library: lib)
 
       case lib
+      when 'bigdecimal-math'
+        loader.add(library: 'bigdecimal')
       when "yaml"
         loader.add(library: "pstore")
         loader.add(library: "dbm")
+      when "logger"
+        loader.add(library: "monitor")
+      when "csv"
+        loader.add(library: "forwardable")
+      when "prime"
+        loader.add(library: "singleton")
       end
 
       new_decls = loader.load(env: @env).map {|decl,| decl }


### PR DESCRIPTION
This pull request adds more fixed dependencies to standard libraries.

# Problem



Currently typeprof command fails if a Ruby code has `require 'logger'`. For example:

```ruby
# test.rb

require 'logger'
```

```console
$ typeprof test.rb
# Analysis Error
A constant `MonitorMixin' is used but not defined in RBS
```


I know this problem because of a Qiita article. https://qiita.com/kure/items/6f93429978466d2860c7#typeprof%E3%81%A7%E3%81%AE%E8%A9%A6%E3%81%BF



# Cause 


Logger actually depends on `MonitorMixin` module that is defined by `monitor` library. But typeprof doesn't know the dependency, so it doesn't load `monitor` library.






# Solution


Add `monitor` library to the loader if `logger` is required. This patch also adds other dependencies.
The list came from here: https://github.com/ruby/rbs/blob/4e5ee848b318c6c9cd4131a825f0b794017acb3a/Rakefile#L35-L54



I know it is an ad-hoc approach, but I think we need the approach currently. Because RBS doesn't have any feature to manage dependency. And actually the users couldn't use typeprof by this problem.