### PR TITLE
Hide to `instance variable not initialized` waring

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -286,6 +286,7 @@ module TypeProf
       @anonymous_struct_gen_id = 0
 
       @types_being_shown = []
+      @namespace = nil
     end
 
     def add_entrypoint(iseq)


### PR DESCRIPTION
I tried `bundle exec rake test` in Ruby 2.7(check in 2.7.0, 2.7.1, 2.7.2), and shown this warning.

```bash
/home/sh/rubydev/typeprof/lib/typeprof/analyzer.rb:496: warning: instance variable @namespace not initialized
```

`@namespace` instance variable initialized code added, and hide to this warning.