### PR TITLE
Add --port option to lsp server for debugging purpose

### DIFF
--- a/lib/typeprof/cli.rb
+++ b/lib/typeprof/cli.rb
@@ -18,6 +18,7 @@ module TypeProf
       verbose = 1
 
       options = {}
+      lsp_options = {}
       dir_filter = nil
       gem_rbs_features = []
       gem_repo_dirs = []
@@ -69,6 +70,10 @@ module TypeProf
       opt.on("--debug", "Display analysis log (for debugging purpose)") { verbose = 2 }
       opt.on("--[no-]stackprof MODE", /\Acpu|wall|object\z/, "Enable stackprof (for debugging purpose)") {|v| options[:stackprof] = v.to_sym }
 
+      opt.separator ""
+      opt.separator "LSP options:"
+      opt.on("--port PORT", Integer, "Specify a port number to listen for requests on") {|v| lsp_options[:port] = v }
+
       opt.parse!(argv)
 
       dir_filter ||= ConfigData::DEFAULT_DIR_FILTER
@@ -88,6 +93,11 @@ module TypeProf
         raise OptionParser::InvalidOption.new("no input files")
       end
 
+      if !options[:lsp] && !lsp_options.empty?
+        exit if show_version
+        raise OptionParser::InvalidOption.new("lsp options with non-lsp mode")
+      end
+
       ConfigData.new(
         rb_files: rb_files,
         rbs_files: rbs_files,
@@ -99,6 +109,7 @@ module TypeProf
         max_sec: max_sec,
         max_iter: max_iter,
         options: options,
+        lsp_options: lsp_options,
       )
 
     rescue OptionParser::InvalidOption

--- a/lib/typeprof/config.rb
+++ b/lib/typeprof/config.rb
@@ -12,6 +12,7 @@ module TypeProf
     :max_iter,
     :max_sec,
     :options,
+    :lsp_options,
     :lsp,
     keyword_init: true
   )
@@ -44,6 +45,9 @@ module TypeProf
         union_width_limit: 10,
         stackprof: nil,
       }.merge(opt[:options])
+      opt[:lsp_options] = {
+        port: 0,
+      }.merge(opt[:lsp_options])
       super(**opt)
     end
 

--- a/lib/typeprof/lsp.rb
+++ b/lib/typeprof/lsp.rb
@@ -4,7 +4,7 @@ require "uri"
 
 module TypeProf
   def self.start_lsp_server(config)
-    Socket.tcp_server_sockets("localhost", 0) do |servs|
+    Socket.tcp_server_sockets("localhost", config.lsp_options[:port]) do |servs|
       serv = servs[0].local_address
       $stdout << JSON.generate({
         host: serv.ip_address,


### PR DESCRIPTION
How to debug the LSP server in your tty with binding.irb:

1. Put typeprof-lsp file with the following content:
```
echo '{"host":"::1","port":8090}'
```

2. Launch typeprof lsp server with port option
```
$ bundle exec typeprof --repo ../ruby/gem_rbs_collection/gems -Ilib --lsp --port 8090
```