### PR TITLE
Should quote var name if identifier_keywords

### DIFF
--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -895,7 +895,7 @@ module TypeProf
         fargs << ("**" + all_val_ty.screen_name(scratch))
       end
       if Config.options[:show_parameter_names]
-        farg_names = farg_names.map {|name| name == :type ? :type_ : name } # XXX: workaround of RBS parser bug
+        farg_names = farg_names.map {|name| RBS::Parser::KEYWORDS.key?(name.to_s) ? "`#{name}`" : name }
         farg_names = farg_names.map {|name| name.is_a?(Integer) ? "noname_#{ name }" : name }
         fargs = fargs.zip(farg_names).map {|farg, name| name ? "#{ farg } #{ name }" : farg }
       end

--- a/smoke/identifier_keywords.rb
+++ b/smoke/identifier_keywords.rb
@@ -1,0 +1,17 @@
+def type(type)
+end
+
+def out(*out)
+end
+
+def untyped(untyped:)
+end
+
+__END__
+# Classes
+class Object
+  private
+  def type: (untyped `type`) -> nil
+  def out: (*untyped `out`) -> nil
+  def untyped: (untyped: untyped) -> nil
+end


### PR DESCRIPTION
I think at least the identifier words in the variable names should be quoted.