### PR TITLE
LSP: Support instance variable definition jump

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -800,6 +800,12 @@ module TypeProf
         end
       end
 
+      def get_read_ep_list(site)
+        entry = @tbl[site]
+        return [] if entry.nil?
+        entry.read_continuations.keys
+      end
+
       def dump
         @tbl
       end
@@ -840,7 +846,12 @@ module TypeProf
       recv.each_child do |recv|
         class_def, singleton = get_ivar(recv, var)
         next unless class_def
-        class_def.ivars.add_write!([singleton, var], ty, ep, self)
+        site = [singleton, var]
+        class_def.ivars.add_write!(site, ty, ep, self)
+        class_def.ivars.get_read_ep_list(site).each do |use_ep|
+          def_insn = ep.ctx.iseq.insns[ep.pc]
+          use_ep.ctx.iseq.add_ivar_def(use_ep.pc, def_insn, ep.ctx.iseq)
+        end
       end
     end
 

--- a/lib/typeprof/iseq.rb
+++ b/lib/typeprof/iseq.rb
@@ -129,6 +129,12 @@ module TypeProf
       end
     end
 
+    def add_ivar_def(pc, def_insn, def_iseq)
+      if @insns[pc].definitions
+        @insns[pc].definitions << [def_iseq.path, def_insn.code_range]
+      end
+    end
+
     attr_reader :name, :path, :absolute_path, :start_lineno, :type, :locals, :fargs_format, :catch_table, :insns
     attr_reader :id, :iseq_code_range
 
@@ -272,7 +278,7 @@ module TypeProf
             end
           end
 
-          if e.code_range && e.insn == :send
+          if e.code_range && (e.insn == :send || e.insn == :getinstancevariable)
             definition = Utils::MutableSet.new
             file_info.definition_table[e.code_range] = definition
           end


### PR DESCRIPTION
## Description

Added support of `Go to instance variable definition`. 

## Known Issue

In `get_foo`, `@foo` can't find the its definition in `set_foo` due to the limitation of current `identify_class_for_ivar` analysis

```ruby
class A
  def set_foo
    @foo = 1
  end
end

class B < A
  def get_foo
    @foo
  end
end
```

## Demo

https://user-images.githubusercontent.com/11702759/128834814-d2c98708-1431-41bf-ae43-30bb91e05cad.mov

