### PR TITLE
LSP: Background analysis

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -984,8 +984,8 @@ module TypeProf
       end
     end
 
-    def type_profile
-      start_time = tick = Time.now
+    def type_profile(cancel_token = Utils::TimerCancelToken.new(Config.max_sec))
+      tick = Time.now
       iter_counter = 0
       stat_eps = Utils::MutableSet.new
 
@@ -1022,7 +1022,7 @@ module TypeProf
               end
             end
 
-            if (Config.max_sec && Time.now - start_time >= Config.max_sec) || (Config.max_iter && Config.max_iter <= iter_counter)
+            if (Config.max_iter && Config.max_iter <= iter_counter) || cancel_token.cancelled?
               @terminated = true
               break
             end

--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -984,7 +984,8 @@ module TypeProf
       end
     end
 
-    def type_profile(cancel_token = Utils::TimerCancelToken.new(Config.max_sec))
+    def type_profile(cancel_token = nil)
+      cancel_token ||= Utils::TimerCancelToken.new(Config.max_sec)
       tick = Time.now
       iter_counter = 0
       stat_eps = Utils::MutableSet.new

--- a/lib/typeprof/config.rb
+++ b/lib/typeprof/config.rb
@@ -66,7 +66,7 @@ module TypeProf
     ]
   end
 
-  def self.analyze(config)
+  def self.analyze(config, cancel_token = nil)
     # Deploy the config to the TypeProf::Config (Note: This is thread unsafe)
     if TypeProf.const_defined?(:Config)
       TypeProf.send(:remove_const, :Config)
@@ -111,7 +111,7 @@ module TypeProf
       scratch.add_entrypoint(iseq)
     end
 
-    result = scratch.type_profile
+    result = scratch.type_profile(cancel_token)
 
     if Config.options[:lsp]
       return scratch.report_lsp, code_range_table

--- a/lib/typeprof/export.rb
+++ b/lib/typeprof/export.rb
@@ -26,7 +26,7 @@ module TypeProf
     end
 
     def show_message(terminated, output)
-      if Config.options[:show_typeprof_version]
+      if Config.current.options[:show_typeprof_version]
         output.puts "# TypeProf #{ VERSION }"
         output.puts
       end
@@ -38,7 +38,7 @@ module TypeProf
 
     def show_error(errors, backward_edge, output)
       return if errors.empty?
-      return unless Config.options[:show_errors]
+      return unless Config.current.options[:show_errors]
 
       output.puts "# Errors"
       errors.each do |ep, msg|
@@ -109,14 +109,14 @@ module TypeProf
       consts = {}
       class_def.consts.each do |name, (ty, absolute_path)|
         next if ty.is_a?(Type::Class)
-        next if !absolute_path || Config.check_dir_filter(absolute_path) == :exclude
+        next if !absolute_path || Config.current.check_dir_filter(absolute_path) == :exclude
         consts[name] = ty.screen_name(@scratch)
       end
 
       modules = class_def.modules.to_h do |kind, mods|
         mods = mods.to_h do |singleton, mods|
           mods = mods.filter_map do |mod_def, _type_args, absolute_paths|
-            next if absolute_paths.all? {|path| !path || Config.check_dir_filter(path) == :exclude }
+            next if absolute_paths.all? {|path| !path || Config.current.check_dir_filter(path) == :exclude }
             Type::Instance.new(mod_def.klass_obj).screen_name(@scratch)
           end
           [singleton, mods]
@@ -139,7 +139,7 @@ module TypeProf
 
             ctx = ctxs.find {|ctx| ctx.mid == mid } || ctxs.first
 
-            next if Config.check_dir_filter(ctx.iseq.absolute_path) == :exclude
+            next if Config.current.check_dir_filter(ctx.iseq.absolute_path) == :exclude
 
             method_name = mid
             method_name = "self.#{ method_name }" if singleton
@@ -149,7 +149,7 @@ module TypeProf
             source_locations[key] ||= ctx.iseq.source_location(0)
             (methods[key] ||= []) << @scratch.show_method_signature(ctx)
           when AliasMethodDef
-            next if mdef.def_ep && Config.check_dir_filter(mdef.def_ep.source_location) == :exclude
+            next if mdef.def_ep && Config.current.check_dir_filter(mdef.def_ep.source_location) == :exclude
             alias_name, orig_name = mid, mdef.orig_mid
             if singleton
               alias_name = "self.#{ alias_name }"
@@ -162,7 +162,7 @@ module TypeProf
           when AttrMethodDef
             next if !mdef.def_ep
             absolute_path = mdef.def_ep.ctx.iseq.absolute_path
-            next if !absolute_path || Config.check_dir_filter(absolute_path) == :exclude
+            next if !absolute_path || Config.current.check_dir_filter(absolute_path) == :exclude
             mid = mid.to_s[0..-2].to_sym if mid.to_s.end_with?("=")
             method_name = mid
             method_name = "self.#{ mid }" if singleton
@@ -192,7 +192,7 @@ module TypeProf
       end
 
       ivars = ivars.map do |(singleton, var), entry|
-        next if entry.absolute_paths.all? {|path| Config.check_dir_filter(path) == :exclude }
+        next if entry.absolute_paths.all? {|path| Config.current.check_dir_filter(path) == :exclude }
         ty = entry.type
         next unless var.to_s.start_with?("@")
         var = "self.#{ var }" if singleton
@@ -202,12 +202,12 @@ module TypeProf
       end.compact
 
       cvars = cvars.map do |var, entry|
-        next if entry.absolute_paths.all? {|path| Config.check_dir_filter(path) == :exclude }
+        next if entry.absolute_paths.all? {|path| Config.current.check_dir_filter(path) == :exclude }
         next if entry.rbs_declared
         [var, entry.type.screen_name(@scratch)]
       end.compact
 
-      if !class_def.absolute_path || Config.check_dir_filter(class_def.absolute_path) == :exclude
+      if !class_def.absolute_path || Config.current.check_dir_filter(class_def.absolute_path) == :exclude
         if methods.keys.all? {|type,| type == :rbs }
           return nil if consts.empty? && modules[:before][true].empty? && modules[:before][false].empty? && modules[:after][true].empty? && modules[:after][false].empty? && ivars.empty? && cvars.empty? && inner_classes.empty?
         end
@@ -247,14 +247,14 @@ module TypeProf
       consts = {}
       class_def.consts.each do |name, (ty, absolute_path)|
         next if ty.is_a?(Type::Class)
-        next if !absolute_path || Config.check_dir_filter(absolute_path) == :exclude
+        next if !absolute_path || Config.current.check_dir_filter(absolute_path) == :exclude
         consts[name] = ty.screen_name(@scratch)
       end
 
       modules = class_def.modules.to_h do |kind, mods|
         mods = mods.to_h do |singleton, mods|
           mods = mods.filter_map do |mod_def, _type_args, absolute_paths|
-            next if absolute_paths.all? {|path| !path || Config.check_dir_filter(path) == :exclude }
+            next if absolute_paths.all? {|path| !path || Config.current.check_dir_filter(path) == :exclude }
             Type::Instance.new(mod_def.klass_obj).screen_name(@scratch)
           end
           [singleton, mods]
@@ -277,7 +277,7 @@ module TypeProf
 
             ctx = ctxs.find {|ctx| ctx.mid == mid } || ctxs.first
 
-            next if Config.check_dir_filter(ctx.iseq.absolute_path) == :exclude
+            next if Config.current.check_dir_filter(ctx.iseq.absolute_path) == :exclude
 
             method_name = mid
             method_name = "self.#{ method_name }" if singleton
@@ -299,7 +299,7 @@ module TypeProf
           when AttrMethodDef
             next if !mdef.def_ep
             absolute_path = mdef.def_ep.ctx.iseq.absolute_path
-            next if !absolute_path || Config.check_dir_filter(absolute_path) == :exclude
+            next if !absolute_path || Config.current.check_dir_filter(absolute_path) == :exclude
             mid = mid.to_s[0..-2].to_sym if mid.to_s.end_with?("=")
             method_name = mid
             method_name = "self.#{ mid }" if singleton
@@ -329,7 +329,7 @@ module TypeProf
       end
 
       ivars = ivars.map do |(singleton, var), entry|
-        next if entry.absolute_paths.all? {|path| Config.check_dir_filter(path) == :exclude }
+        next if entry.absolute_paths.all? {|path| Config.current.check_dir_filter(path) == :exclude }
         ty = entry.type
         next unless var.to_s.start_with?("@")
         var = "self.#{ var }" if singleton
@@ -339,12 +339,12 @@ module TypeProf
       end.compact
 
       cvars = cvars.map do |var, entry|
-        next if entry.absolute_paths.all? {|path| Config.check_dir_filter(path) == :exclude }
+        next if entry.absolute_paths.all? {|path| Config.current.check_dir_filter(path) == :exclude }
         next if entry.rbs_declared
         [var, entry.type.screen_name(@scratch)]
       end.compact
 
-      if !class_def.absolute_path || Config.check_dir_filter(class_def.absolute_path) == :exclude
+      if !class_def.absolute_path || Config.current.check_dir_filter(class_def.absolute_path) == :exclude
         if methods.keys.all? {|type,| type == :rbs }
           return nil if consts.empty? && modules[:before][true].empty? && modules[:before][false].empty? && modules[:after][true].empty? && modules[:after][false].empty? && ivars.empty? && cvars.empty?
         end
@@ -512,7 +512,7 @@ module TypeProf
           prev_vis = vis
         end
         source_location = class_data.source_locations[key]
-        if Config.options[:show_source_locations] && source_location
+        if Config.current.options[:show_source_locations] && source_location
           lines << nil
           lines << (indent + "  # #{ source_location }")
         end
@@ -520,7 +520,7 @@ module TypeProf
         case type
         when :attr
           kind, ty, untyped = *arg
-          exclude = Config.options[:exclude_untyped] && untyped ? "#" : " " # XXX
+          exclude = Config.current.options[:exclude_untyped] && untyped ? "#" : " " # XXX
           lines << (indent + "#{ exclude } attr_#{ kind } #{ method_name }#{ hidden ? "()" : "" }: #{ ty }")
         when :rbs
           sigs = arg.sort.join("\n" + indent + "#" + " " * (method_name.size + 5) + "| ")
@@ -533,7 +533,7 @@ module TypeProf
             untyped ||= untyped0
           end
           sigs = sigs.sort.join("\n" + indent + " " * (method_name.size + 6) + "| ")
-          exclude = Config.options[:exclude_untyped] && untyped ? "#" : " " # XXX
+          exclude = Config.current.options[:exclude_untyped] && untyped ? "#" : " " # XXX
           lines << (indent + "#{ exclude } def #{ method_name }: #{ sigs }")
         when :alias
           orig_name = arg

--- a/lib/typeprof/import.rb
+++ b/lib/typeprof/import.rb
@@ -4,7 +4,7 @@ module TypeProf
   class RBSReader
     def initialize
       @repo = RBS::Repository.new
-      Config.gem_repo_dirs.each do |dir|
+      Config.current.gem_repo_dirs.each do |dir|
         @repo.add(Pathname(dir))
       end
       @env, @builtin_env_json = RBSReader.get_builtin_env

--- a/lib/typeprof/lsp.rb
+++ b/lib/typeprof/lsp.rb
@@ -68,7 +68,9 @@ module TypeProf
           end
         end
 
-        on_text_changed
+        # analyze synchronously to respond the first codeLens request
+        res, def_table = self.analyze(uri, text)
+        on_text_changed_analysis(res, def_table)
       end
 
       attr_reader :text, :version, :sigs
@@ -125,7 +127,8 @@ module TypeProf
         lines = @text.lines
         lines[row][start_offset, end_offset] = ".__typeprof_lsp_completion"
         tmp_text = lines.join
-        res, = analyze(@uri, tmp_text)
+        res, def_table = analyze(@uri, tmp_text)
+        return if res.nil?
         if res[:completion]
           results = res[:completion].keys.map do |name|
             {

--- a/lib/typeprof/lsp.rb
+++ b/lib/typeprof/lsp.rb
@@ -17,7 +17,9 @@ module TypeProf
 
       Socket.accept_loop(servs) do |sock|
         begin
-          TypeProf::LSP::Server.new(config, sock).run
+          reader = LSP::Reader.new(sock)
+          writer = LSP::Writer.new(sock)
+          TypeProf::LSP::Server.new(config, reader, writer).run
         ensure
           sock.close
         end
@@ -535,10 +537,10 @@ module TypeProf
 
       include Helpers
 
-      def initialize(config, read_io, write_io = read_io)
+      def initialize(config, reader, writer)
         @typeprof_config = config
-        @reader = Reader.new(read_io)
-        @writer = Writer.new(write_io)
+        @reader = reader
+        @writer = writer
         @request_id = 0
         @current_requests = {}
         @open_texts = {}

--- a/lib/typeprof/method.rb
+++ b/lib/typeprof/method.rb
@@ -37,7 +37,7 @@ module TypeProf
       locals.each_with_index do |ty, i|
         alloc_site2 = alloc_site.add_id(i)
         # nenv is top-level, so it is okay to call Type#localize directly
-        nenv, ty = ty.localize(nenv, alloc_site2, Config.options[:type_depth_limit])
+        nenv, ty = ty.localize(nenv, alloc_site2, Config.current.options[:type_depth_limit])
         nenv = nenv.local_update(i, ty)
       end
 
@@ -97,14 +97,14 @@ module TypeProf
       idx = 0
       msig.lead_tys.each_with_index do |ty, i|
         alloc_site2 = alloc_site.add_id(idx += 1)
-        ty = ty.substitute(cur_subst, Config.options[:type_depth_limit]).remove_type_vars
+        ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
         nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
         nenv = nenv.local_update(i, ty)
       end
       if msig.opt_tys
         msig.opt_tys.each_with_index do |ty, i|
           alloc_site2 = alloc_site.add_id(idx += 1)
-          ty = ty.substitute(cur_subst, Config.options[:type_depth_limit]).remove_type_vars
+          ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
           nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
           nenv = nenv.local_update(lead_num + i, ty)
         end
@@ -112,14 +112,14 @@ module TypeProf
       if msig.rest_ty
         alloc_site2 = alloc_site.add_id(idx += 1)
         ty = Type::Array.new(Type::Array::Elements.new([], msig.rest_ty), Type::Instance.new(Type::Builtin[:ary]))
-        ty = ty.substitute(cur_subst, Config.options[:type_depth_limit]).remove_type_vars
+        ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
         nenv, rest_ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
         nenv = nenv.local_update(rest_start, rest_ty)
       end
       if msig.post_tys
         msig.post_tys.each_with_index do |ty, i|
           alloc_site2 = alloc_site.add_id(idx += 1)
-          ty = ty.substitute(cur_subst, Config.options[:type_depth_limit]).remove_type_vars
+          ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
           nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
           nenv = nenv.local_update(post_start + i, ty)
         end
@@ -132,7 +132,7 @@ module TypeProf
             next
           end
           alloc_site2 = alloc_site.add_id(key)
-          ty = ty.substitute(cur_subst, Config.options[:type_depth_limit]).remove_type_vars
+          ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
           nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
           nenv = nenv.local_update(kw_start + i, ty)
         end
@@ -140,7 +140,7 @@ module TypeProf
       if msig.kw_rest_ty
         ty = msig.kw_rest_ty
         alloc_site2 = alloc_site.add_id(:**)
-        ty = ty.substitute(cur_subst, Config.options[:type_depth_limit]).remove_type_vars
+        ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
         nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
         nenv = nenv.local_update(kw_rest, ty)
       end
@@ -257,7 +257,7 @@ module TypeProf
             bsig = msig.blk_ty.block_body.msig
             alloc_site = AllocationSite.new(caller_ep).add_id(self)
             nlead_tys = (bsig.lead_tys + bsig.opt_tys).map.with_index do |ty, i|
-              ty = ty.substitute(subst, Config.options[:type_depth_limit]).remove_type_vars
+              ty = ty.substitute(subst, Config.current.options[:type_depth_limit]).remove_type_vars
               dummy_env, ty = scratch.localize_type(ty, dummy_env, dummy_ep, alloc_site.add_id(i))
               ty
             end
@@ -271,7 +271,7 @@ module TypeProf
                     ncaller_env = recv_orig.update_container_elem_type(subst2, ncaller_env, caller_ep, scratch)
                     scratch.merge_return_env(caller_ep) {|env| env ? env.merge(ncaller_env) : ncaller_env }
                   end
-                  ret_ty2 = ret_ty.substitute(subst2, Config.options[:type_depth_limit]).remove_type_vars
+                  ret_ty2 = ret_ty.substitute(subst2, Config.current.options[:type_depth_limit]).remove_type_vars
                 else
                   ret_ty2 = Type.any
                 end
@@ -289,7 +289,7 @@ module TypeProf
             ctn[ret_ty, caller_ep, ncaller_env] if ret_ty != Type.bot
           end
         else
-          ret_ty = ret_ty.substitute(subst, Config.options[:type_depth_limit])
+          ret_ty = ret_ty.substitute(subst, Config.current.options[:type_depth_limit])
           ret_ty = ret_ty.remove_type_vars
           ctn[ret_ty, caller_ep, ncaller_env] if ret_ty != Type.bot
         end

--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -168,7 +168,7 @@ module TypeProf
     end
 
     def remove_type_vars
-      substitute(DummySubstitution, Config.options[:type_depth_limit])
+      substitute(DummySubstitution, Config.current.options[:type_depth_limit])
     end
 
     def include_untyped?(_scratch)
@@ -239,7 +239,7 @@ module TypeProf
               non_class_instances << ty
             end
           end
-          if (Config.options[:union_width_limit] >= 2 && class_instances.size >= Config.options[:union_width_limit]) || (degenerated && class_instances.size >= 2)
+          if (Config.current.options[:union_width_limit] >= 2 && class_instances.size >= Config.current.options[:union_width_limit]) || (degenerated && class_instances.size >= 2)
             create(Utils::Set[Instance.new_degenerate(class_instances), *non_class_instances], elems)
           else
             new(tys, elems)
@@ -322,7 +322,7 @@ module TypeProf
             types.delete(Type::Instance.new(Type::Builtin[:true]))
             bool = true
           end
-          types.delete(Type.any) unless Config.options[:show_untyped]
+          types.delete(Type.any) unless Config.current.options[:show_untyped]
           proc_tys, types = types.partition {|ty| ty.is_a?(Proc) }
           types = types.map {|ty| ty.screen_name(scratch) }
           types << scratch.show_proc_signature(proc_tys) unless proc_tys.empty?
@@ -783,7 +783,7 @@ module TypeProf
       when ::Hash
         Type.gen_hash do |h|
           obj.each do |k, v|
-            k_ty = guess_literal_type(k).globalize(nil, {}, Config.options[:type_depth_limit])
+            k_ty = guess_literal_type(k).globalize(nil, {}, Config.current.options[:type_depth_limit])
             v_ty = guess_literal_type(v)
             h[k_ty] = v_ty
           end
@@ -891,7 +891,7 @@ module TypeProf
         end
         fargs << ("**" + all_val_ty.screen_name(scratch))
       end
-      if Config.options[:show_parameter_names]
+      if Config.current.options[:show_parameter_names]
         farg_names = farg_names.map {|name| RBS::Parser::KEYWORDS.key?(name.to_s) ? "`#{name}`" : name }
         farg_names = farg_names.map {|name| name.is_a?(Integer) ? "noname_#{ name }" : name }
         fargs = fargs.zip(farg_names).map {|farg, name| name ? "#{ farg } #{ name }" : farg }

--- a/lib/typeprof/utils.rb
+++ b/lib/typeprof/utils.rb
@@ -9,7 +9,7 @@ module TypeProf
       def self.included(klass)
         klass.instance_eval do
           def new(*args)
-            (@table ||= {})[[self] + args] ||= super
+            (Thread.current[:table] ||= {})[[self] + args] ||= super
           end
         end
       end

--- a/lib/typeprof/utils.rb
+++ b/lib/typeprof/utils.rb
@@ -191,5 +191,22 @@ module TypeProf
         "#<#{ self.class }:#{ @heap.map {|_key, val| val }.inspect }>"
       end
     end
+
+    class CancelToken
+      def cancelled?
+        return false
+      end
+    end
+
+    class TimerCancelToken < CancelToken
+      def initialize(max_sec)
+        @max_sec = max_sec
+        @start_time = Time.now
+      end
+
+      def cancelled?
+        @max_sec && Time.now - @start_time >= @max_sec
+      end
+    end
   end
 end

--- a/test/typeprof/lsp_test.rb
+++ b/test/typeprof/lsp_test.rb
@@ -86,5 +86,111 @@ module TypeProf
         # defs = definition_table[CodeLocation.new(15, 4)].to_a
         # assert_equal(defs[0][1].inspect, "(6,4)-(6,12)")
     end
+
+    test "ensure threads write responses exclusively" do
+      class Verifier
+        def initialize(ctx)
+          @rx = Thread::Queue.new
+          @ctx = ctx
+        end
+
+        def read
+          yield ({ id: 0, method: "initialize" })
+          yield ({ method: "initialized" })
+          yield ({
+            method: "textDocument/didOpen",
+            params: {
+              textDocument: {
+                uri: "file:///path/to/file.rb",
+                languageId: "ruby",
+                version: 1,
+                text: <<~EOS
+                  class Foo
+                    def foo(a, b, c)
+                      bar(a)
+                    end
+                    def bar(a)
+                      1
+                    end
+                  end
+                  if $0 == __FILE__
+                    obj = Foo.new
+                    obj.foo(1, "str", obj)
+                    obj.bar(1)
+                  end
+                EOS
+              }
+            }
+          })
+          @ctx.assert_equal(@rx.pop[:id], 0)
+
+          yield ({
+            method: "textDocument/didChange",
+            params: {
+              textDocument: {
+                uri: "file:///path/to/file.rb",
+                version: 4
+              },
+              contentChanges: [
+                {
+                  range: {
+                    start: { line: 6, character: 5 },
+                    end:   { line: 6, character: 5 }
+                  },
+                  rangeLength: 0,
+                  text: "."
+                }
+              ]
+            }
+          })
+
+          @ctx.assert_equal(@rx.pop[:method], "workspace/codeLens/refresh")
+          @ctx.assert_equal(@rx.pop[:method], "textDocument/publishDiagnostics")
+
+          # id=1,2 are proceed in parallel
+          yield ({
+            id: 1,
+            method: "textDocument/codeLens",
+            params: {
+              textDocument: { uri: "file:///path/to/file.rb" },
+            }
+          })
+
+          yield ({
+            id: 2,
+            method: "textDocument/completion",
+            params: {
+              textDocument: { uri: "file:///path/to/file.rb" },
+              position: { line: 6, character: 6 },
+              context: { triggerKind: 2, triggerCharacter: "." }
+            }
+          })
+          # receive id=1,2
+          res1, res2 = @rx.pop, @rx.pop
+          res = {
+            res1[:id] => res1,
+            res2[:id] => res2
+          }
+          @ctx.assert_not_empty(res[1][:result])
+          @ctx.assert_not_empty(res[2][:result])
+        end
+
+        def write(**json)
+          if @writing
+            @ctx.assert(false, "non exclusive call")
+          end
+          @writing = true
+          @rx << json
+          @writing = false
+        end
+      end
+
+      config = ConfigData.new(options: {
+        lsp: true
+      })
+      verifier = Verifier.new(self)
+      server = TypeProf::LSP::Server.new(config, verifier, verifier)
+      server.run
+    end
   end
 end


### PR DESCRIPTION
## Description

- Analyze input code in background thread for every `textDocument/didChange`
  - Each analysis are proceed sequentially in a job queue
  - If new analysis request happened and the previous analysis has not been done yet, the previous one will be cancelled to perform the latest one ASAP.
  - `textDocument/codeLens` responder is proceed in the same  job queue because it's order sensitive with `textDocument/didChange`
- `textDocument/completion` is not order sensitive with `textDocument/didChange`, so completion analysis is performed in another thread
- Now two threads perform `TypeProf.analyze` in parallel, so `TypeProf.Config` have to be stored in TLS

## Before and after

https://user-images.githubusercontent.com/11702759/129526354-ddf9db1b-ce8d-4d9a-835f-155bd92f37e7.mov


https://user-images.githubusercontent.com/11702759/129526371-e4cba882-405b-45f6-a201-627488d6abf9.mov


