### PR TITLE
LSP: Fix instance variable jump for read-before-write case

### DIFF
--- a/test/typeprof/lsp_test.rb
+++ b/test/typeprof/lsp_test.rb
@@ -100,6 +100,13 @@ module TypeProf
             @foo
           end
         end
+
+        class C
+          def read_write
+            _ = @bar
+            @bar = 1
+          end
+        end
         EOS
 
         # use in a class that defines the ivar
@@ -111,6 +118,10 @@ module TypeProf
         # TODO: analyze ivar definition based on inheritance hierarchy
         # defs = definition_table[CodeLocation.new(15, 4)].to_a
         # assert_equal(defs[0][1].inspect, "(6,4)-(6,12)")
+
+        # use before def
+        defs = definition_table[CodeLocation.new(21, 9)].to_a
+        assert_equal(defs[0][1].inspect, "(22,4)-(22,12)")
     end
 
     test "analyze const definition" do


### PR DESCRIPTION
~Depends on https://github.com/ruby/typeprof/pull/47~

If an instance var is read before written in a scope, analyzer couldn't find the writer locations because it didn't use continuation-style API.