### PR TITLE
Ignore incomplete signatures in the middle of analysis

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -2442,6 +2442,7 @@ module TypeProf
 
     def show_method_signature(ctx)
       farg_tys = @method_signatures[ctx]
+      return nil unless farg_tys
       ret_ty = ctx.mid == :initialize ? Type::Void.new : @return_values[ctx] || Type.bot
 
       untyped = farg_tys.include_untyped?(self) || ret_ty.include_untyped?(self)

--- a/lib/typeprof/export.rb
+++ b/lib/typeprof/export.rb
@@ -287,7 +287,8 @@ module TypeProf
             key = [:iseq, method_name]
             visibilities[key] ||= mdef.pub_meth
             source_locations[key] ||= [ctx.iseq.source_location(0)]
-            (methods[key] ||= []) << @scratch.show_method_signature(ctx)
+            sig = @scratch.show_method_signature(ctx)
+            (methods[key] ||= []) << sig if sig
           when AliasMethodDef
             alias_name, orig_name = mid, mdef.orig_mid
             if singleton


### PR DESCRIPTION
An analysis can be cancelled in the middle due to timeout, so some of
method signatures can be nil after an analysis.