### PR TITLE
Show "Array[untyped]" when an empty array is guessed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    typeprof (0.15.1)
+    typeprof (0.15.2)
       rbs (>= 1.3.1)
 
 GEM
@@ -11,7 +11,7 @@ GEM
     docile (1.4.0)
     power_assert (2.0.0)
     rake (13.0.1)
-    rbs (1.3.3)
+    rbs (1.5.1)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/typeprof/container-type.rb
+++ b/lib/typeprof/container-type.rb
@@ -307,7 +307,11 @@ module TypeProf
         def screen_name(scratch)
           if @rest_ty == Type.bot
             if @lead_tys.empty?
-              return "Array[bot]" # RBS does not allow an empty tuple "[]"
+              # This is heuristic: in general, an empty array is a wrong guess.
+              # Note that an empty array is representable as "[ ]" in RBS, but
+              # users often have to modify it to "Array[something]".
+              # In this term, "Array[untyped]" is considered more useful than "[ ]".
+              return "Array[untyped]"
             end
             s = @lead_tys.map do |ty|
               ty.screen_name(scratch)
@@ -673,6 +677,8 @@ module TypeProf
               k_ty = k_ty.union(k)
               v_ty = v_ty.union(v)
             end
+            k_ty = Type.any if k_ty == Type.bot
+            v_ty = Type.any if v_ty == Type.bot
             k_ty = k_ty.screen_name(scratch)
             v_ty = v_ty.screen_name(scratch)
             "Hash[#{ k_ty }, #{ v_ty }]"

--- a/smoke/array15.rb
+++ b/smoke/array15.rb
@@ -12,5 +12,5 @@ Foo.new[1] = "str"
 __END__
 # Classes
 class Foo
-  def []=: (*Integer | String args) -> Array[bot]
+  def []=: (*Integer | String args) -> Array[untyped]
 end

--- a/smoke/array6.rb
+++ b/smoke/array6.rb
@@ -10,8 +10,8 @@ foo(1, "str")
 __END__
 # Classes
 class Object
-  ARY: Array[bot]
+  ARY: Array[untyped]
 
   private
-  def foo: (Integer i, String v) -> Array[bot]
+  def foo: (Integer i, String v) -> Array[untyped]
 end

--- a/smoke/array8.rb
+++ b/smoke/array8.rb
@@ -9,5 +9,5 @@ end
 __END__
 # Classes
 class Foo
-  def self.foo: (Array[bot] a) -> Array[bot]
+  def self.foo: (Array[untyped] a) -> Array[untyped]
 end

--- a/smoke/block-args2.rb
+++ b/smoke/block-args2.rb
@@ -48,11 +48,11 @@ __END__
 class Object
   private
   def f1: { -> nil } -> ^(nil, *bot, nil) -> nil
-  def log1: (nil a, Array[bot] r, nil c) -> nil
+  def log1: (nil a, Array[untyped] r, nil c) -> nil
   def f2: { (:a) -> nil } -> ^(:a, *bot, nil) -> nil
-  def log2: (:a a, Array[bot] r, nil c) -> nil
+  def log2: (:a a, Array[untyped] r, nil c) -> nil
   def f3: { (:a, :b) -> nil } -> ^(:a, *bot, :b) -> nil
-  def log3: (:a a, Array[bot] r, :b c) -> nil
+  def log3: (:a a, Array[untyped] r, :b c) -> nil
   def f4: { (:a, :b, :c) -> nil } -> ^(:a, *:b, :c) -> nil
   def log4: (:a a, [:b] r, :c c) -> nil
   def f5: { (:a, :b, :c, :d) -> nil } -> (^(:a, *:b | :c, :d) -> nil)

--- a/smoke/block-args3.rb
+++ b/smoke/block-args3.rb
@@ -57,13 +57,13 @@ __END__
 class Object
   private
   def f1: { -> nil } -> ^(nil, ?:opt, *bot, nil) -> nil
-  def log1: (nil a, :opt o, Array[bot] r, nil c) -> nil
+  def log1: (nil a, :opt o, Array[untyped] r, nil c) -> nil
   def f2: { (:a) -> nil } -> ^(:a, ?:opt, *bot, nil) -> nil
-  def log2: (:a a, :opt o, Array[bot] r, nil c) -> nil
+  def log2: (:a a, :opt o, Array[untyped] r, nil c) -> nil
   def f3: { (:a, :b) -> nil } -> ^(:a, ?:opt, *bot, :b) -> nil
-  def log3: (:a a, :opt o, Array[bot] r, :b c) -> nil
+  def log3: (:a a, :opt o, Array[untyped] r, :b c) -> nil
   def f4: { (:a, :b, :c) -> nil } -> (^(:a, ?:b | :opt, *bot, :c) -> nil)
-  def log4: (:a a, :b | :opt o, Array[bot] r, :c c) -> nil
+  def log4: (:a a, :b | :opt o, Array[untyped] r, :c c) -> nil
   def f5: { (:a, :b, :c, :d) -> nil } -> (^(:a, ?:b | :opt, *:c, :d) -> nil)
   def log5: (:a a, :b | :opt o, [:c] r, :d c) -> nil
   def f6: { (:a, :b, :c, :d, :e) -> nil } -> (^(:a, ?:b | :opt, *:c | :d, :e) -> nil)

--- a/smoke/hash-bot.rb
+++ b/smoke/hash-bot.rb
@@ -8,5 +8,5 @@ __END__
 # Classes
 class Object
   private
-  def foo: -> Hash[Integer, Array[bot]]
+  def foo: -> Hash[Integer, Array[untyped]]
 end

--- a/smoke/hash4.rb
+++ b/smoke/hash4.rb
@@ -7,5 +7,5 @@ __END__
 # Classes
 class Object
   private
-  def foo: -> Hash[bot, bot]
+  def foo: -> Hash[untyped, untyped]
 end

--- a/smoke/parameterizedd-self.rb
+++ b/smoke/parameterizedd-self.rb
@@ -13,8 +13,8 @@ bar([])
 __END__
 # Classes
 class Object
-  def foo: -> Array[bot]
+  def foo: -> Array[untyped]
 
   private
-  def bar: (Array[bot] ary) -> Array[bot]
+  def bar: (Array[untyped] ary) -> Array[untyped]
 end

--- a/test/typeprof/goodcheck_test.rb
+++ b/test/typeprof/goodcheck_test.rb
@@ -45,15 +45,15 @@ module TypeProf
     attr_reader trigger: untyped
     attr_reader buffer: Buffer
     def initialize: (rule: untyped, trigger: untyped, buffer: Buffer) -> void
-    def scan: ?{ (Issue) -> Array[bot]? } -> ((Array[Issue] | Enumerator[Issue, untyped] | Enumerator[bot, untyped])?)
-    def scan_simple: (Regexp regexp) ?{ (Issue) -> Array[bot]? } -> Array[Issue]?
+    def scan: ?{ (Issue) -> Array[untyped]? } -> ((Array[Issue] | Enumerator[Issue, untyped] | Enumerator[bot, untyped])?)
+    def scan_simple: (Regexp regexp) ?{ (Issue) -> Array[untyped]? } -> Array[Issue]?
     def scan_var: (untyped pat) ?{ (Issue) -> untyped } -> nil
   end
         END
 
         assert(actual =~ /^module Goodcheck\n.*(^  class Trigger\n(?:(?:    .*?\n|\n)*)^  end\n).*^end\n/m)
         actual = $1
-        exp = TypeProf::ISeq::CASE_WHEN_CHECKMATCH ? "untyped" : "Array\\[bot\\]"
+        exp = TypeProf::ISeq::CASE_WHEN_CHECKMATCH ? "untyped" : "Array\\[untyped\\]"
         assert_match(Regexp.compile(Regexp.quote(<<-END).gsub("HOLE", exp)), actual)
   class Trigger
     @by_pattern: bool


### PR DESCRIPTION
Formerly, an empty array is shown as "Array[bot]".
It is representable as "[ ]" in RBS, but it is considered that an empty
array is a wrong guess due to the analysis limitation of TypeProf.
Typically, users often have to modify it to "Array[something]".
So, "Array[untyped]" is considered more useful than "[ ]".

Similarly, "Hash[bot, bot]" is changed to "Hash[untyped, untyped]".