### PR TITLE
Enable rbs collection support

### DIFF
--- a/lib/typeprof/cli.rb
+++ b/lib/typeprof/cli.rb
@@ -23,6 +23,7 @@ module TypeProf
       gem_repo_dirs = []
       show_version = false
       max_sec = max_iter = nil
+      collection_path = RBS::Collection::Config::PATH
 
       opt.separator ""
       opt.separator "Options:"
@@ -33,6 +34,8 @@ module TypeProf
       opt.on("-I DIR", "Add DIR to the load/require path") {|v| $LOAD_PATH << v }
       opt.on("-r FEATURE", "Require RBS of the FEATURE gem") {|v| gem_rbs_features << v }
       opt.on("--repo DIR", "Add DIR to the RBS repository") {|v| gem_repo_dirs << v }
+      opt.on("--collection PATH", "File path of collection configuration") { |v| collection_path = v }
+      opt.on("--no-collection", "Ignore collection configuration") { collection_path = nil }
 
       opt.separator ""
       opt.separator "Analysis output options:"
@@ -93,6 +96,7 @@ module TypeProf
         output: output,
         gem_rbs_features: gem_rbs_features,
         gem_repo_dirs: gem_repo_dirs,
+        collection_path: collection_path,
         verbose: verbose,
         dir_filter: dir_filter,
         max_sec: max_sec,

--- a/lib/typeprof/config.rb
+++ b/lib/typeprof/config.rb
@@ -7,6 +7,7 @@ module TypeProf
     :output,
     :gem_rbs_features,
     :gem_repo_dirs,
+    :collection_path,
     :verbose,
     :dir_filter,
     :max_iter,
@@ -80,6 +81,9 @@ module TypeProf
     Config.gem_rbs_features.each do |feature|
       Import.import_library(scratch, feature)
     end
+
+    collection_path = config.collection_path
+    Import.import_rbs_collection(scratch, collection_path) if collection_path&.exist?
 
     rbs_files = []
     rbs_codes = []

--- a/lib/typeprof/import.rb
+++ b/lib/typeprof/import.rb
@@ -66,6 +66,14 @@ module TypeProf
       RBSReader.load_rbs(@env, new_decls)
     end
 
+    def load_rbs_collection(collection_path)
+      loader = RBS::EnvironmentLoader.new(core_root: nil)
+      collection_lock = RBS::Collection::Config.lockfile_of(collection_path)
+      loader.add_collection(collection_lock)
+      new_decls = loader.load(env: @env).map {|decl,| decl }
+      RBSReader.load_rbs(@env, new_decls)
+    end
+
     def self.load_rbs(env, new_decls)
       all_env = env.resolve_type_names
       resolver = RBS::TypeNameResolver.from_env(all_env)
@@ -512,6 +520,10 @@ module TypeProf
 
     def self.import_rbs_code(scratch, rbs_name, rbs_code)
       Import.new(scratch, scratch.rbs_reader.load_rbs_string(rbs_name, rbs_code)).import(true)
+    end
+
+    def self.import_rbs_collection(scratch, collection_path)
+      Import.new(scratch, scratch.rbs_reader.load_rbs_collection(collection_path)).import(true)
     end
 
     def initialize(scratch, json)


### PR DESCRIPTION
This patch adds rbs collection feature to TypeProf.
See https://github.com/ruby/rbs/pull/589 for more details of rbs collection.



TypeProf will behave the following by this patch.

* If `rbs_collection.yaml` exists in the current directory, TypeProf loads libraries' RBSs from the config file.
* If `--collection PATH` option is specified, TypeProf loads libraries' RBSs from the specified file.
* If `--no-collection` option is specified, Typeprof ignores `rbs_collection.yaml`.
* If `rbs_collection.yaml` doesn't exist and no options are specified, TypeProf does nothing about rbs collection feature.


The option names are the exactly same as `rbs` command's options.


# Testing 


I've confirmed the feature works with the following procedure.

1. put the following files
    * Gemfile
      ```ruby
      source 'https://rubygems.org'

      gem 'ast'
      ```
    * Gemfile.lock
      ```
      GEM
        remote: https://rubygems.org/
        specs:
          ast (2.4.2)

      PLATFORMS
        x86_64-linux

      DEPENDENCIES
        ast

      BUNDLED WITH
         2.2.27
      ```
    * rbs_collection.yaml
      ```
      # Download sources
      sources:
        - name: ruby/gem_rbs_collection
          remote: https://github.com/ruby/gem_rbs_collection.git
          revision: main
          repo_dir: gems

      # A directory to install the downloaded RBSs
      path: .gem_rbs_collection

      gems:
        # Skip loading rbs gem's RBS.
        # It's unnecessary if you don't use rbs as a library.
        - name: rbs
          ignore: true
      ```
    * test.rb
      ```
      require 'ast'

      class C
        def x(node)
          node.children
        end
      end

      node = AST::Node.new(:x, [:foo, 42])
      C.new.x node
      ```
1. Run `rbs collection install` to install RBS for `ast` gem
1. Run `typeprof test.rb`
    * It displays the following result.
      ```
      $ typeprof test.rb
      warning: rbs collection is experimental, and the behavior may change until RBS v2.0
      # TypeProf 0.15.3

      # Classes
      class C
        def x: (AST::Node node) -> Array[untyped]
      end
      ```
    * It is aware of `ast` gem's type :muscle:
