### PR TITLE
Support rbs 1.7.0.beta.3

### DIFF
--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -895,7 +895,7 @@ module TypeProf
         fargs << ("**" + all_val_ty.screen_name(scratch))
       end
       if Config.options[:show_parameter_names]
-        farg_names = farg_names.map {|name| RBS::Parser::KEYWORDS.key?(name.to_s) ? "`#{name}`" : name }
+        farg_names = farg_names.map {|name| RBS::Parser::KEYWORDS.include?(name.to_s) ? "`#{name}`" : name }
         farg_names = farg_names.map {|name| name.is_a?(Integer) ? "noname_#{ name }" : name }
         fargs = fargs.zip(farg_names).map {|farg, name| name ? "#{ farg } #{ name }" : farg }
       end


### PR DESCRIPTION
In rbs v1.7.0.beta.3, `RBS::Parser::KEYWORDS` seems to change from Hash to Set.
`#include?` will be able to support both.

ref: https://github.com/ruby/rbs/commit/a2f4592960762fcd45cab71fd951d59010934b84