### PR TITLE
Make Type.any, Type.nil, etc. be thread-local

### DIFF
--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -422,22 +422,22 @@ module TypeProf
     end
 
     def self.any
-      @any ||= Any.new
+      Thread.current[:any] ||= Any.new
     end
 
     def self.bot
-      @bot ||= Union.new(Utils::Set[], nil)
+      Thread.current[:bot] ||= Union.new(Utils::Set[], nil)
     end
 
     def self.bool
-      @bool ||= Union.new(Utils::Set[
+      Thread.current[:bool] ||= Union.new(Utils::Set[
         Instance.new(Type::Builtin[:true]),
         Instance.new(Type::Builtin[:false])
       ], nil)
     end
 
     def self.nil
-      @nil ||= Instance.new(Type::Builtin[:nil])
+      Thread.current[:nil] ||= Instance.new(Type::Builtin[:nil])
     end
 
     def self.optional(ty)


### PR DESCRIPTION
Follow up of 0ad4c28e011ad85c822f6c680178d3c5e0f5d92d.

Now the Type objects are all thread-local.
"Type::Instance.new(<NilClass>)" returns a different object for each
thread. However, However, Type.nil cached the object in an instance
ariable of the class object, which brought inconsistency, i.e.,
"Type.nil === Type::Instance.new(<NilClass>)" may return false.