### PR TITLE
Fix: Use cmd /c for windows

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -88,6 +88,9 @@ function executeTypeProf(folder: vscode.WorkspaceFolder, arg: String): child_pro
   if (shell && (shell.endsWith("bash") || shell.endsWith("zsh") || shell.endsWith("fish"))) {
     typeprof = child_process.spawn(shell, ["-c", "-l", cmd], { cwd });
   }
+  else if (process.platform === "win32") {
+    typeprof = child_process.spawn("cmd", ["/c", cmd], { cwd });
+  }
   else {
     typeprof = child_process.spawn(cmd, { cwd });
   }

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -89,7 +89,7 @@ function executeTypeProf(folder: vscode.WorkspaceFolder, arg: String): child_pro
     typeprof = child_process.spawn(shell, ["-c", "-l", cmd], { cwd });
   }
   else if (process.platform === "win32") {
-    typeprof = child_process.spawn("cmd", ["/c", cmd], { cwd });
+    typeprof = child_process.spawn("C:\\Windows\\System32\\cmd.exe", ["/c", cmd], { cwd });
   }
   else {
     typeprof = child_process.spawn(cmd, { cwd });


### PR DESCRIPTION
LSP didn't work in windows:
```
[vscode] Try to start TypeProf for IDE
[vscode] typeprof is not supported for this folder: [object Object]
[vscode] because: Error: spawn bundle exec typeprof --version ENOENT
```
But using `cmd /c` worked for me, so I added this in typeprof LSP. If `process.platform` is `win32` and `shell` is undefined, LSP will use `cmd /c` like `bash -l -c`.
