### PR TITLE
Failing Net::HTTP smoke test

### DIFF
--- a/smoke/rbs-net-http.rb
+++ b/smoke/rbs-net-http.rb
@@ -1,0 +1,25 @@
+module Net
+  class HTTP
+    class IOError < StandardError; end
+
+    def start  # :yield: http
+      raise IOError, 'HTTP session already opened' if @started
+      if block_given?
+        begin
+          do_start
+          return yield(self)
+        ensure
+          do_finish
+        end
+      end
+      do_start
+      self
+    end
+
+    def do_start
+    end
+
+    def do_finish
+    end
+  end
+end

--- a/smoke/rbs-net-http.rbs
+++ b/smoke/rbs-net-http.rbs
@@ -1,0 +1,6 @@
+module Net
+  class HTTP
+    def start: [T] () { (Net::HTTP) -> T } -> T
+             | () -> Net::HTTP
+  end
+end


### PR DESCRIPTION
Trying to evaluate net-http with its rbs fails. I'll try to narrow down the specific issue more if I can.