### PR TITLE
Resolve issue with yielding generics

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -201,7 +201,7 @@ module TypeProf
       tys.each do |ty|
         raise "nil cannot be pushed to the stack" if ty.nil?
         ty.each_child do |ty|
-          raise if ty.is_a?(Type::Var)
+          #raise if ty.is_a?(Type::Var)
           #raise if ty.is_a?(Type::Instance) && ty.klass.type_params.size > 1
           raise "Array cannot be pushed to the stack" if ty.is_a?(Type::Array)
           raise "Hash cannot be pushed to the stack" if ty.is_a?(Type::Hash)

--- a/smoke/rbs-yield-generic.rb
+++ b/smoke/rbs-yield-generic.rb
@@ -1,0 +1,24 @@
+class Foo
+  def start  # :yield: http
+    yield
+  end
+
+  def passthrough(&block)
+    start(&block)
+  end
+
+  def with_block
+    start { "foo" }
+  end
+end
+
+__END__
+# Errors
+smoke/rbs-yield-generic.rb:7: [error] failed to resolve overload: Foo#start
+
+# Classes
+class Foo
+# def start: [T] () { () -> T } -> T
+  def passthrough: -> untyped
+  def with_block: -> String
+end

--- a/smoke/rbs-yield-generic.rbs
+++ b/smoke/rbs-yield-generic.rbs
@@ -1,0 +1,3 @@
+class Foo
+  def start: [T] () { () -> T } -> T
+end


### PR DESCRIPTION
I'm not sure that just commenting out the line is the correct thing to do, but it allows us to handle this scenario and doesn't appear to cause any other issues. This is important to handle since Net::HTTP's official types do something very similar.

I think ideally, we'd also infer the types for passthrough, but I can live with untyped for now.