### PR TITLE
Don't generate duplicate class method definitions

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -1421,7 +1421,16 @@ module TypeProf
         cref = ep.ctx.cref
         recv.each_child do |recv|
           if recv.is_a?(Type::Class)
-            meth = add_singleton_iseq_method(recv, mid, iseq, cref, nil, env.static_env.pub_meth)
+            typed_mdef = check_typed_method(recv, mid, true)
+            if typed_mdef
+              mdef = ISeqMethodDef.new(iseq, cref, nil, env.static_env.pub_meth)
+              typed_mdef.each do |typed_mdef|
+                typed_mdef.do_match_iseq_mdef(mdef, recv, mid, env, ep, self)
+              end
+            else
+              meth = add_singleton_iseq_method(recv, mid, iseq, cref, nil, env.static_env.pub_meth)
+            end
+
             pend_method_execution(iseq, meth, recv, mid, ep.ctx.cref, nil)
           else
             recv = Type.any # XXX: what to do?

--- a/smoke/rbs-duplicate-class-method.rb
+++ b/smoke/rbs-duplicate-class-method.rb
@@ -1,0 +1,28 @@
+class Foo
+  def self.foo?
+    !!@foo
+  end
+
+  def self.bar?
+    !!@bar
+  end
+
+  def foo?
+    self.class.foo?
+  end
+
+  def bar?
+    self.class.bar?
+  end
+end
+__END__
+# Classes
+class Foo
+  self.@foo: bot
+  self.@bar: bot
+
+# def self.foo?: -> bool
+# def foo?: -> bool
+  def self.bar?: -> bool
+  def bar?: -> bool
+end

--- a/smoke/rbs-duplicate-class-method.rbs
+++ b/smoke/rbs-duplicate-class-method.rbs
@@ -1,0 +1,4 @@
+class Foo
+  def self.foo?: -> bool
+  def foo?: -> bool
+end

--- a/smoke/rbs-module-method.rb
+++ b/smoke/rbs-module-method.rb
@@ -1,0 +1,12 @@
+module Foo
+  def self.foo?
+    !!@foo
+  end
+end
+__END__
+# Classes
+module Foo
+  self.@foo: bot
+
+# def self.foo?: -> bool
+end

--- a/smoke/rbs-module-method.rbs
+++ b/smoke/rbs-module-method.rbs
@@ -1,0 +1,3 @@
+module Foo
+  def self.foo?: -> bool
+end


### PR DESCRIPTION
I suspect we could probably share some code with `do_define_iseq_method` but I don't feel entirely confident in doing that correctly.