### PR TITLE
Use binmode for stdin/stdout with lsp stdio mode

### DIFF
--- a/lib/typeprof/lsp.rb
+++ b/lib/typeprof/lsp.rb
@@ -5,6 +5,8 @@ require "uri"
 module TypeProf
   def self.start_lsp_server(config)
     if config.lsp_options[:stdio]
+      $stdin.binmode
+      $stdout.binmode
       reader = LSP::Reader.new($stdin)
       writer = LSP::Writer.new($stdout)
       # pipe all builtin print output to stderr to avoid conflicting with lsp


### PR DESCRIPTION
Now typeprof works fine with vim-lsp-settings on Windows too.

![screenshot](https://user-images.githubusercontent.com/10111/147456504-d3fc8d85-ea3b-4475-b83d-7d89ac3e702e.gif)


https://github.com/mattn/vim-lsp-settings/pull/523