### PR TITLE
Change options in execTypeProf

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -86,7 +86,7 @@ function executeTypeProf(folder: vscode.WorkspaceFolder, arg: String): child_pro
   const shell = process.env.SHELL;
   let typeprof: child_process.ChildProcessWithoutNullStreams;
   if (shell && (shell.endsWith("bash") || shell.endsWith("zsh") || shell.endsWith("fish"))) {
-    typeprof = child_process.spawn(shell, ["-c", "-l", cmd], { cwd });
+    typeprof = child_process.spawn(shell, ["-l", "-c", cmd], { cwd });
   }
   else if (process.platform === "win32") {
     typeprof = child_process.spawn("C:\\Windows\\System32\\cmd.exe", ["/c", cmd], { cwd });


### PR DESCRIPTION
I'm using `fish` as login shell, and I cannot exec typeprof vscode extension.
Error message is following.
![Screenshot from 2021-12-27 20-23-40](https://user-images.githubusercontent.com/748445/147529724-f2e26318-b17a-4a9d-9b7f-a12219449cb7.png)

I think the cause of this error is that bash and zsh's `-c` option takes first non option argument as command, but fish's `-c` option needs to take command just after `-c`.
