### PR TITLE
Fix for extension not working on fish shell

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -86,7 +86,8 @@ function executeTypeProf(folder: vscode.WorkspaceFolder, arg: String): child_pro
   const shell = process.env.SHELL;
   let typeprof: child_process.ChildProcessWithoutNullStreams;
   if (shell && (shell.endsWith("bash") || shell.endsWith("zsh") || shell.endsWith("fish"))) {
-    typeprof = child_process.spawn(shell, ["-l", "-c", cmd], { cwd });
+    const options = shell.endsWith("fish") ? ["-c"] : ["-l", "-c"];
+    typeprof = child_process.spawn(shell, [...options, cmd], { cwd });
   }
   else if (process.platform === "win32") {
     typeprof = child_process.spawn("C:\\Windows\\System32\\cmd.exe", ["/c", cmd], { cwd });


### PR DESCRIPTION
In fish shell `-l` option is not recognized and fails to start typeprof. This is a fix for fish shell users.