### PR TITLE
Update the version of typeprof described in the documentation

### DIFF
--- a/doc/ide.md
+++ b/doc/ide.md
@@ -77,7 +77,7 @@ TypeProf for IDE is extremely preliminary! Please give it a try with a warm hear
 
 ## How to develop TypeProf for IDE
 
-See `../vscode/development.md`.
+See [../vscode/development.md](../vscode/development.md).
 
 ## See also
 

--- a/doc/ide.md
+++ b/doc/ide.md
@@ -56,7 +56,9 @@ module RBSWiki
 
 ### Troubleshooting
 
-*TBD*
+* Note that in bash, `~/.bashrc` and `~/.bash_profile` do not contain scripts that assume that pseudo-TTYs are available (such as the `bind` command). 
+  * TypeProf for IDE will run `typeprof --version` at startup to parse STDOUT and make sure the proper version is running.
+  * If the `.bashrc` contains a command that requires a pseudo-TTY, such as the `bind` command, unexpected error messages will be output to STDOUT, and the LSP server will stop because it fails to parse the execution results of the `typeprof` command.
 
 ## Protips, limitation, unimplemented features, ...
 

--- a/doc/ide.md
+++ b/doc/ide.md
@@ -23,19 +23,18 @@ $ ruby -v
 ruby 3.1.0p0 (2021-12-25 revision fb4df44d16) [x86_64-linux]
 ```
 
-* Check if typeprof version is 0.20.0 or later.
+* Check if typeprof version is 0.21.2 or later.
 
 ```
 $ bundle exec typeprof --version
-typeprof 0.20.0
+typeprof 0.21.2
 ```
 
 * Check if TypeProf can analyze `lib/rbswiki/wiki.rb` within one second.
 
 ```
 $ bundle exec typeprof lib/rbswiki/wiki.rb
-warning: rbs collection is experimental, and the behavior may change until RBS v2.0
-# TypeProf 0.20.0
+# TypeProf 0.21.2
 
 # Classes
 module RBSWiki


### PR DESCRIPTION
When using the stable version of Ruby 3.1.0, some parts of the documentation were different from the actual behavior.

See also:
- https://github.com/mame/rbswiki/pull/1