### PR TITLE
Fix ExecuteCommand unresponsive

### DIFF
--- a/lib/typeprof/lsp.rb
+++ b/lib/typeprof/lsp.rb
@@ -500,9 +500,11 @@ module TypeProf
         when "typeprof.enableSignature"
           @server.signature_enabled = true
           @server.send_request("workspace/codeLens/refresh")
+          respond(nil)
         when "typeprof.disableSignature"
           @server.signature_enabled = false
           @server.send_request("workspace/codeLens/refresh")
+          respond(nil)
         when "typeprof.createPrototypeRBS"
           class_kind, class_name, sig_str = @params[:arguments]
           code_range =


### PR DESCRIPTION
When I tried to executeCommand with emacs-lsp, it kept waiting for a response until it timed out.

This PR has been fixed to respond correctly.