### PR TITLE
Relax overload resolution for container types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,4 +36,4 @@ DEPENDENCIES
   typeprof!
 
 BUNDLED WITH
-   2.2.15
+   2.3.11

--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -59,10 +59,13 @@ module TypeProf
         else
           if ty2.is_a?(Type::ContainerType)
             # ty2 may have type variables
-            return nil if ty1.class != ty2.class
-            ty1.match?(ty2)
+            if ty1.class == ty2.class
+              ty1.match?(ty2)
+            else
+              Type.match?(ty1, ty2.base_type)
+            end
           elsif ty1.is_a?(Type::ContainerType)
-            nil
+            Type.match?(ty1.base_type, ty2)
           else
             ty1.consistent?(ty2) ? {} : nil
           end

--- a/smoke/range2.rb
+++ b/smoke/range2.rb
@@ -1,0 +1,8 @@
+s = "foo"
+p s[0..1]
+
+__END__
+# Revealed types
+#  smoke/range2.rb:2 #=> String?
+
+# Classes


### PR DESCRIPTION
e.g., `str[0..-2]`