### PR TITLE
Handle Regexp-related special variables as non-nil

### DIFF
--- a/lib/typeprof/analyzer.rb
+++ b/lib/typeprof/analyzer.rb
@@ -1997,7 +1997,8 @@ module TypeProf
             env = env.push(Type.any) # or String | NilClass only?
           when 1 # VM_SVAR_BACKREF ($~)
             merge_env(ep.next, env.push(Type::Instance.new(Type::Builtin[:matchdata])))
-            merge_env(ep.next, env.push(Type.nil))
+            # tentatively disabled; it is too conservative
+            #merge_env(ep.next, env.push(Type.nil))
             return
           else # flip-flop
             env = env.push(Type.bool)
@@ -2005,7 +2006,8 @@ module TypeProf
         else
           # NTH_REF ($1, $2, ...) / BACK_REF ($&, $+, ...)
           merge_env(ep.next, env.push(Type::Instance.new(Type::Builtin[:str])))
-          merge_env(ep.next, env.push(Type.nil))
+          # tentatively disabled; it is too conservative
+          #merge_env(ep.next, env.push(Type.nil))
           return
         end
       when :setspecial

--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -813,7 +813,9 @@ module TypeProf
       when :$0, :$PROGRAM_NAME
         Type::Instance.new(Type::Builtin[:str])
       when :$~
-        Type.optional(Type::Instance.new(Type::Builtin[:matchdata]))
+        # optional type is tentatively disabled; it is too conservative
+        #Type.optional(Type::Instance.new(Type::Builtin[:matchdata]))
+        Type::Instance.new(Type::Builtin[:matchdata])
       when :$., :$$
         Type::Instance.new(Type::Builtin[:int])
       when :$?

--- a/smoke/svar1.rb
+++ b/smoke/svar1.rb
@@ -9,5 +9,5 @@ __END__
 # Classes
 class Object
   private
-  def foo: -> [String?, String?]
+  def foo: -> [String, String]
 end


### PR DESCRIPTION
Now `$~`, `$1`, etc. evaluates to non-nil. Though they are theoretically
nilable, it easily leads to many false positive warnings. Steep and
Sorbet handles them as non-nil, so I'd like to follow them here.

In future, we may add more dedicated analysis for Regexp matching.