### PR TITLE
Add $typeprof as always true for type annotation

### DIFF
--- a/smoke/typeprof-gvar.rb
+++ b/smoke/typeprof-gvar.rb
@@ -1,0 +1,9 @@
+x = 42
+x = "foo" if $typeprof
+p(x)
+
+__END__
+# Revealed types
+#  smoke/typeprof-gvar.rb:3 #=> String
+
+# Classes


### PR DESCRIPTION
This feature may very controversial, but it allows to force cast a type
as follows:

    x = 42
    x = "foo" if $typeprof
    p(x)  #=> String

Unfortunately, TypeProf often does wrong type inference, which is
unavoidable. However, there was no simple way to correct the inference.
To be honest I don't like this feature, but writing RBS may be too heavy
for correcting trivial misinferences.