### PR TITLE
Add minimal support for TruffleRuby so `typeprof --version` and `require "typeprof"` work

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,15 +11,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-      with:
-        submodules: true
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-    - name: Bundle install
-      run: |
-        bundle install
+        bundler-cache: true
     - name: Run the test suite
       run: |
         bundle exec rake TESTOPT=-v
+
+  truffleruby:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: truffleruby
+        bundler-cache: true
+    - run: bundle exec typeprof --version

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 
 group :development do
   gem "rake"
-  gem "stackprof"
+  gem "stackprof", platforms: :mri
   gem "test-unit"
   gem "simplecov"
   gem "simplecov-html"

--- a/lib/typeprof.rb
+++ b/lib/typeprof.rb
@@ -17,4 +17,4 @@ require_relative "typeprof/builtin"
 require_relative "typeprof/cli"
 require_relative "typeprof/code-range"
 
-require_relative "typeprof/lsp" if RUBY_VERSION >= "3"
+require_relative "typeprof/lsp" if RUBY_VERSION >= "3" and RUBY_ENGINE != "truffleruby"

--- a/lib/typeprof/iseq.rb
+++ b/lib/typeprof/iseq.rb
@@ -1,11 +1,13 @@
 module TypeProf
   class ISeq
-    # https://github.com/ruby/ruby/pull/4468
-    CASE_WHEN_CHECKMATCH = RubyVM::InstructionSequence.compile("case 1; when Integer; end").to_a.last.any? {|insn,| insn == :checkmatch }
-    # https://github.com/ruby/ruby/blob/v3_0_2/vm_core.h#L1206
-    VM_ENV_DATA_SIZE = 3
-    # Check if Ruby 3.1 or later
-    RICH_AST = begin RubyVM::AbstractSyntaxTree.parse("1", keep_script_lines: true).node_id; true; rescue; false; end
+    if defined?(RubyVM::InstructionSequence)
+      # https://github.com/ruby/ruby/pull/4468
+      CASE_WHEN_CHECKMATCH = RubyVM::InstructionSequence.compile("case 1; when Integer; end").to_a.last.any? {|insn,| insn == :checkmatch }
+      # https://github.com/ruby/ruby/blob/v3_0_2/vm_core.h#L1206
+      VM_ENV_DATA_SIZE = 3
+      # Check if Ruby 3.1 or later
+      RICH_AST = begin RubyVM::AbstractSyntaxTree.parse("1", keep_script_lines: true).node_id; true; rescue; false; end
+    end
 
     FileInfo = Struct.new(
       :node_id2node,


### PR DESCRIPTION
* Fixes https://github.com/ruby/typeprof/issues/64

The original fix https://github.com/ruby/typeprof/commit/988563ce1e125d4ebdc45e7e196c32e0f90c6956 is no longer enough, so let's add the check in CI to know it keeps working.

Users might add `typeprof` to their Gemfile and so it's useful if it installs and requires cleanly on TruffleRuby.