### PR TITLE
Use `name` property for more clearly log

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -115,7 +115,7 @@ function getTypeProfVersion(folder: vscode.WorkspaceFolder, outputChannel: vscod
     }
   });
   typeprof.on("error", e => {
-    log(`typeprof is not supported for this folder: ${folder}`);
+    log(`typeprof is not supported for this folder: ${folder.name}`);
     log(`because: ${e}`);
   });
   typeprof.on("exit", (code) => {


### PR DESCRIPTION
# Before
```
typeprof is not supported for this folder: [object Object]
```
# After
```
typeprof is not supported for this folder: sampleProgram
```