### PR TITLE
Load ".zshrc" when default shell is zsh

### DIFF
--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -86,7 +86,16 @@ function executeTypeProf(folder: vscode.WorkspaceFolder, arg: String): child_pro
   const shell = process.env.SHELL;
   let typeprof: child_process.ChildProcessWithoutNullStreams;
   if (shell && (shell.endsWith("bash") || shell.endsWith("zsh") || shell.endsWith("fish"))) {
-    typeprof = child_process.spawn(shell, ["-l", "-c", cmd], { cwd });
+		const args: string[] = [];
+		if (shell.endsWith('zsh')) {
+			// As the recommended way, initialization commands for rbenv are written in ".zshrc".
+			// However, it's not loaded on the non-interactive shell.
+			// Thus, we need to run this command as the interactive shell.
+			// FYI: https://zsh.sourceforge.io/Guide/zshguide02.html
+			args.push('-i');
+		}
+		args.push("-l", "-c", cmd);
+    typeprof = child_process.spawn(shell, args, { cwd });
   }
   else if (process.platform === "win32") {
     typeprof = child_process.spawn(process.env.SYSTEMROOT + "\\System32\\cmd.exe", ["/c", cmd], { cwd });


### PR DESCRIPTION
The reason for https://github.com/ruby/typeprof/issues/128 is not loading ".zshrc". Thus, the initialization command for rbenv is not loaded and the wrong path for ruby is used.

As the recommended way, initialization commands for rbenv are written in ".zshrc". However, it's not loaded on the non-interactive shell. We need to run this command as the interactive shell.
FYI: https://zsh.sourceforge.io/Guide/zshguide02.html