### PR TITLE
Support the bytecode spec change of Ruby 3.3

### DIFF
--- a/lib/typeprof/method.rb
+++ b/lib/typeprof/method.rb
@@ -117,6 +117,12 @@ module TypeProf
         ty = Type::Array.new(Type::Array::Elements.new([], msig.rest_ty), Type::Instance.new(Type::Builtin[:ary]))
         ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
         nenv, rest_ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
+        # TODO: handle a case where rest_start is not found
+        nenv = nenv.local_update(rest_start, rest_ty)
+      elsif rest_start
+        alloc_site2 = alloc_site.add_id(idx += 1)
+        ty = Type::Array.new(Type::Array::Elements.new([], Type.any), Type::Instance.new(Type::Builtin[:ary]))
+        nenv, rest_ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
         nenv = nenv.local_update(rest_start, rest_ty)
       end
       if msig.post_tys
@@ -144,6 +150,11 @@ module TypeProf
         ty = msig.kw_rest_ty
         alloc_site2 = alloc_site.add_id(:**)
         ty = ty.substitute(cur_subst, Config.current.options[:type_depth_limit]).remove_type_vars
+        nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
+        nenv = nenv.local_update(kw_rest, ty)
+      elsif kw_rest
+        alloc_site2 = alloc_site.add_id(:**)
+        ty = Type.gen_hash {}
         nenv, ty = scratch.localize_type(ty, nenv, callee_ep, alloc_site2)
         nenv = nenv.local_update(kw_rest, ty)
       end

--- a/smoke/define_method4.rb
+++ b/smoke/define_method4.rb
@@ -1,3 +1,4 @@
+# RUBY_VERSION >= 3.3
 class Foo
   define_method(:foo) do |*messages, **kw|
     bar(*messages, **kw)
@@ -11,5 +12,5 @@ __END__
 # Classes
 class Foo
 # def foo: () -> NilClass
-  def bar: (*untyped messages, **untyped) -> nil
+  def bar: (*untyped messages, **bot) -> nil
 end

--- a/smoke/kwsplat2-2.rb
+++ b/smoke/kwsplat2-2.rb
@@ -1,4 +1,5 @@
-# RUBY_VERSION < 3.3
+# RUBY_VERSION >= 3.3
+
 def foo(*r, k:)
 end
 
@@ -10,5 +11,5 @@ __END__
 # Classes
 class Object
   private
-  def foo: (*Integer | {k: Integer} r, k: Integer) -> nil
+  def foo: (*Integer r, k: Integer) -> nil
 end

--- a/test/typeprof/smoke_test.rb
+++ b/test/typeprof/smoke_test.rb
@@ -8,9 +8,10 @@ module TypeProf
       name = "smoke/" + File.basename(path) 
 
       code, expected = File.read(path).split("__END__\n")
-      if code =~ /\A(?:#.*\n)*# RUBY_VERSION >= (\d+)\.(\d+)$/
+      case code
+      when /\A(?:#.*\n)*# RUBY_VERSION (>=|>|<|<=|==) (\d+)\.(\d+)$/
         major, minor = RUBY_VERSION.split(".")[0, 2].map {|s| s.to_i }
-        next unless ([major, minor] <=> [$1.to_i, $2.to_i]) >= 0
+        next unless ([major, minor] <=> [$2.to_i, $3.to_i]).send($1, 0)
       end
 
       show_errors = true


### PR DESCRIPTION
RubyVM bytecode will be changed when both *ary and **kwrest are passed.

https://github.com/ruby/ruby/pull/7128

This absorbs the spec change.