### PR TITLE
Show error messages when error occurs after running lsp server

### DIFF
--- a/lib/typeprof/lsp.rb
+++ b/lib/typeprof/lsp.rb
@@ -352,6 +352,7 @@ module TypeProf
           }
         end
 
+        @server.send_notification('typeprof.enableToggleButton')
         @server.send_request("workspace/codeLens/refresh")
 
         @server.send_notification(
@@ -827,6 +828,13 @@ module TypeProf
       end
     end
 
+    module MessageType
+      Error = 1
+      Warning = 2
+      Info = 3
+      Log = 4
+    end
+
     class Server
       class Exit < StandardError; end
 
@@ -861,6 +869,20 @@ module TypeProf
           end
         end
       rescue Exit
+      rescue => e
+        msg = "Tyeprof fatal error: #{e.message}"
+        send_notification(
+          'window/showMessage',
+          type: MessageType::Error,
+          message: msg
+        )
+        send_notification(
+          'window/logMessage',
+          type: MessageType::Error,
+          message: "#{msg} Backtrace: #{e.backtrace}"
+        )
+        send_notification('typeprof.showErrorStatus')
+        retry
       end
 
       def send_response(**msg)

--- a/test/typeprof/lsp_test.rb
+++ b/test/typeprof/lsp_test.rb
@@ -380,6 +380,7 @@ module TypeProf
             }
           })
 
+          @ctx.assert_equal(@rx.pop[:method], "typeprof.enableToggleButton")
           @ctx.assert_equal(@rx.pop[:method], "workspace/codeLens/refresh")
           @ctx.assert_equal(@rx.pop[:method], "textDocument/publishDiagnostics")
 


### PR DESCRIPTION
When "workspace/codeLens/refresh" is sent, "typeprof.enableToggleButton" is sent.
Then, toggle button is showed.
When error occurs, "typeprof.showErrorStatus" is sent.
Then, error status is showed in the status bar.