### PR TITLE
Fix error with collection_path

### DIFF
--- a/lib/typeprof/import.rb
+++ b/lib/typeprof/import.rb
@@ -31,7 +31,7 @@ module TypeProf
           lock_path = RBS::Collection::Config.to_lockfile_path(collection_path)
           if lock_path.exist?
             collection_lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lock_path, data: YAML.load_file(lock_path.to_s))
-            collection_lock.gems.each {|gem| @loaded_gems << gem["name"] }
+            collection_lock.gems.each {|_, gem| @loaded_gems << gem[:name] }
             loader.add_collection(collection_lock)
           else
             raise "Please execute 'rbs collection install'"


### PR DESCRIPTION
The problem occurred when using a combination of TypeProf and rbs collection.

```
TypeError: no implicit conversion of String into Integer
```

---

`collection_lock.gems` returns `Hash[String, library]`

https://github.com/ruby/rbs/blob/c24c65ce867c7d1cc3cc1ca871fc002579bd8854/sig/collection/config/lockfile.rbs#L48

And, `library` is record type.

https://github.com/ruby/rbs/blob/c24c65ce867c7d1cc3cc1ca871fc002579bd8854/sig/collection/config/lockfile.rbs#L24-L28


I wrote a test for using the rbs collection, but gave up because the `@builtin_env` class instance variable for `TypeProf::Config` is cached and would affect other tests.