### PR TITLE
Fix TypeError for RBS::Collection::Config::Lockfile#gems

### DIFF
--- a/lib/typeprof/import.rb
+++ b/lib/typeprof/import.rb
@@ -31,7 +31,7 @@ module TypeProf
           lock_path = RBS::Collection::Config.to_lockfile_path(collection_path)
           if lock_path.exist?
             collection_lock = RBS::Collection::Config::Lockfile.from_lockfile(lockfile_path: lock_path, data: YAML.load_file(lock_path.to_s))
-            collection_lock.gems.each_value {|gem| @loaded_gems << gem["name"] }
+            collection_lock.gems.each_value {|gem| @loaded_gems << gem[:name] }
             loader.add_collection(collection_lock)
           else
             raise "Please execute 'rbs collection install'"


### PR DESCRIPTION
This patch aims to fix the following error:

```
/.../vendor/bundle/ruby/3.2.0/gems/typeprof-0.21.7/lib/typeprof/import.rb:34:in `[]': no implicit conversion of String into Integer (TypeError)

            collection_lock.gems.each {|gem| @loaded_gems << gem["name"] }
                                                                 ^^^^^^
```

A value (`library` type) of a Hash object returned by `RBS::Collection::Config::Lockfile#gems` should include the `:name` key:
- https://github.com/ruby/rbs/blob/ebb5257241c/sig/collection/config/lockfile.rbs#L48
- https://github.com/ruby/rbs/blob/ebb5257241c/sig/collection/config/lockfile.rbs#L24-L28