### PR TITLE
Improve CLI error handling

### DIFF
--- a/lib/typeprof/cli.rb
+++ b/lib/typeprof/cli.rb
@@ -118,9 +118,9 @@ module TypeProf
         lsp_options: lsp_options,
       )
 
-    rescue OptionParser::InvalidOption
+    rescue OptionParser::InvalidOption, OptionParser::MissingArgument
       puts $!
-      exit
+      exit 1
     end
   end
 end


### PR DESCRIPTION
- Return exit code `1` instead of `0` when an error occurs
- Simplify an error message when `OptionParser::MissingArgument` occurs

For example:

```console
$ bundle exec exe/typeprof ; echo $?
invalid option: no input files
1

$ bundle exec exe/typeprof --port ; echo $?
missing argument: --port
1
```