### PR TITLE
Make the test suite compatible with `--enable-frozen-string-literal`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        include:
+          - ruby: "3.3"
+            rubyopt: "--enable-frozen-string-literal"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -35,5 +38,5 @@ jobs:
     - run: bundle exec typeprof --version
     - name: Run the test suite
       run: |
-        bundle exec rake TESTOPT=-v
+        bundle exec rake TESTOPT=-v RUBYOPT="${{ matrix.rubyopt }}"
       if: ${{ !startsWith(matrix.ruby, 'truffle') }}

--- a/lib/typeprof/type.rb
+++ b/lib/typeprof/type.rb
@@ -861,7 +861,7 @@ module TypeProf
     include Utils::StructuralEquality
 
     def screen_name(iseq, scratch)
-      fargs_str = "("
+      fargs_str = +"("
       sig_help = {}
       add_farg = -> farg, name, help: false, key: sig_help.size do
         name = "`#{ name }`" if RBS::Parser::KEYWORDS.key?(name.to_s)
@@ -917,7 +917,7 @@ module TypeProf
 
       fargs_str << ")"
 
-      fargs_str = "" if fargs_str == "()"
+      fargs_str = +"" if fargs_str == "()"
 
       # Dirty Hack: Stop the iteration at most once!
       # I'll remove this hack if RBS removes the limitation of nesting blocks

--- a/test/typeprof/cli_test.rb
+++ b/test/typeprof/cli_test.rb
@@ -7,7 +7,7 @@ module TypeProf
       rb_file = File.join(__dir__, "../../smoke/simple.rb")
       rb_files = [rb_file, rb_file]
       rbs_files = []
-      output = StringIO.new("")
+      output = StringIO.new(+"")
       options = {}
       options[:show_untyped] = true
       options[:show_errors] = true
@@ -37,7 +37,7 @@ end
       rb_file = File.join(__dir__, "../../smoke/any1.rb")
       rb_files = [rb_file]
       rbs_files = []
-      output = StringIO.new("")
+      output = StringIO.new(+"")
       options = {}
       options[:exclude_untyped] = true
       options[:show_untyped] = true
@@ -67,7 +67,7 @@ end
       rb_file = File.join(__dir__, "../../smoke/simple.rb")
       rb_files = [rb_file]
       rbs_files = [["test.rbs", "class Bar < Foo\nend"]]
-      output = StringIO.new("")
+      output = StringIO.new(+"")
       options = {}
       options[:show_untyped] = true
       options[:show_errors] = true

--- a/test/typeprof/test_helper.rb
+++ b/test/typeprof/test_helper.rb
@@ -24,7 +24,7 @@ module TypeProf
 
       rb_files = [@name]
       rbs_files = [@rbs_path].compact
-      output = StringIO.new("")
+      output = StringIO.new(+"")
       options[:show_untyped] = true unless options.key?(:show_untyped)
       options[:show_errors] = true unless options.key?(:show_errors)
       options[:show_indicator] = false unless options.key?(:show_indicator)


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/20205
Ref: https://github.com/voxpupuli/json-schema/pull/508

Since `typeprof` is tested as part of ruby-core CI, it needs to be compatible with the `--enable-frozen-string-literal` option.

cc @mame 