### PR TITLE
Let service definitions return code ranges scoped to name

### DIFF
--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -176,7 +176,7 @@ module TypeProf::Core
               site.resolve(genv, nil) do |me, _ty, _mid, _orig_ty|
                 next unless me
                 me.defs.each do |mdef|
-                  defs << [mdef.node.lenv.path, mdef.node.code_range]
+                  defs << [mdef.node.lenv.path, mdef.node.mid_code_range]
                 end
               end
             end

--- a/scenario/service/definition.rb
+++ b/scenario/service/definition.rb
@@ -13,7 +13,7 @@ Foo.new(1).foo(1.0)
 test.rb:(1,0)-(7,3)
 
 ## definition: test.rb:9:5
-test.rb:(2,2)-(3,5)
+test.rb:(2,6)-(2,16)
 
 ## definition: test.rb:9:12
-test.rb:(5,2)-(6,5)
+test.rb:(5,6)-(5,9)


### PR DESCRIPTION
## Summary

service#definitions with method call returns full code range of def node now, which results to point `def` keyword.
IMO, which is not expected behavior, and it supposed to move cursor to the start of the method name. I confirmed rust analyzer, js lsp do the same thing, so proposed behavior is more friendly to end user.

## Changes

`DefNode`'s mid_code_range attr has name token loc, so just return it instead of which could be enough.
Ref: https://github.com/ruby/typeprof/blob/1601d0cbc7e367cc8f731669b162c613e3280e97/lib/typeprof/core/ast/method.rb#L117
or should we override `code_range` method of `Node` class? 🤔 