### PR TITLE
Provide fallback when mid_code_range method not exist

### DIFF
--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -176,7 +176,13 @@ module TypeProf::Core
               site.resolve(genv, nil) do |me, _ty, _mid, _orig_ty|
                 next unless me
                 me.defs.each do |mdef|
-                  defs << [mdef.node.lenv.path, mdef.node.mid_code_range]
+                  code_range =
+                    case mdef.node
+                    when AST::DefNode then mdef.node.mid_code_range
+                    else mdef.node.code_range
+                    end
+
+                  defs << [mdef.node.lenv.path, code_range]
                 end
               end
             end

--- a/scenario/service/definition.rb
+++ b/scenario/service/definition.rb
@@ -1,6 +1,11 @@
 ## update: test.rb
 class Foo
+  BAR = 1
+
+  attr_reader :bar, :baz
+
   def initialize(n)
+    @bar = n
   end
 
   def foo(n)
@@ -8,12 +13,24 @@ class Foo
 end
 
 Foo.new(1).foo(1.0)
+Foo.new(1).bar
+Foo.new(1).baz
+Foo::BAR
 
-## definition: test.rb:9:1
-test.rb:(1,0)-(7,3)
+## definition: test.rb:14:1
+test.rb:(1,0)-(12,3)
 
-## definition: test.rb:9:5
-test.rb:(2,6)-(2,16)
+## definition: test.rb:14:5
+test.rb:(6,6)-(6,16)
 
-## definition: test.rb:9:12
-test.rb:(5,6)-(5,9)
+## definition: test.rb:14:12
+test.rb:(10,6)-(10,9)
+
+## definition: test.rb:15:12
+test.rb:(4,2)-(4,24)
+
+## definition: test.rb:16:12
+test.rb:(4,2)-(4,24)
+
+## definition: test.rb:17:5
+test.rb:(2,2)-(2,9)


### PR DESCRIPTION
Fix https://github.com/ruby/typeprof/pull/162

## Summary

#162 breaks GoToDef on attr_reader / attr_accessor, so this pr provide fallback when mid_code_range.
And add some test about current behavior