### PR TITLE
Enable to comment on scenario test

### DIFF
--- a/scenario/service/definition.rb
+++ b/scenario/service/definition.rb
@@ -23,28 +23,28 @@ Foo::CCAR
 Foo::DDAR
 
 ## definition: test.rb:14:1
-test.rb:(1,6)-(1,9)
+test.rb:(1,6)-(1,9) # Jump to Foo class
 
 ## definition: test.rb:14:5
-test.rb:(6,6)-(6,16)
+test.rb:(6,6)-(6,16) # Jump Foo.initialize from Foo.new
 
 ## definition: test.rb:14:12
-test.rb:(10,6)-(10,9)
+test.rb:(10,6)-(10,9) # Jump to Foo#foo
 
 ## definition: test.rb:15:12
-test.rb:(4,2)-(4,24)
+test.rb:(4,2)-(4,24) # Jump to Foo#bar (first arg of attr_reader)
 
 ## definition: test.rb:16:12
-test.rb:(4,2)-(4,24)
+test.rb:(4,2)-(4,24) # Jump to Foo#baz (second arg of attr_reader)
 
 ## definition: test.rb:17:5
-test.rb:(2,2)-(2,5)
+test.rb:(2,2)-(2,5) # Jump to Foo#BAR (constant_write_node)
 
 ## definition: test.rb:19:5
-test.rb:(18,0)-(18,9)
+test.rb:(18,0)-(18,9) # Jump to Foo#BBAR (constant_path_write_node)
 
 ## definition: test.rb:21:5
-test.rb:(20,0)-(20,9)
+test.rb:(20,0)-(20,9) # Jump to Foo#BBAR (first arg of constant_path_target_node)
 
 ## definition: test.rb:22:5
-test.rb:(20,11)-(20,20)
+test.rb:(20,11)-(20,20) # Jump to Foo#BBAR (second arg of constant_path_target_node)

--- a/test/scenario_compiler.rb
+++ b/test/scenario_compiler.rb
@@ -39,6 +39,7 @@ class ScenarioCompiler
       out << "core = TypeProf::Core::Service.new;"
     end
     close_str = ""
+    need_comment_removal = false
     File.foreach(scenario, chomp: true) do |line|
       if line =~ /\A##\s*/
         out << close_str
@@ -52,11 +53,16 @@ class ScenarioCompiler
           open_str, close_str = ary
           out << open_str.chomp
           close_str += "\n"
+          need_comment_removal = true if $1 == "definition"
         else
           raise "unknown directive: #{ line.inspect }"
         end
       else
         raise "NUL found" if line.include?("\0")
+        if need_comment_removal
+          line = line.gsub(/#\s*.*\Z/, "")
+          need_comment_removal = false
+        end
         out << line << "\n"
       end
     end


### PR DESCRIPTION
## Summary

scenario test is really good to assert test case, but a little bit hard to read each assertion's intend.
this pr adds magic comment `## comment:`, which ignored on scenario compile and add some comment to defintion test as example.
