### PR TITLE
Let goDef jump to each element on attr_{reader,accessor}

### DIFF
--- a/lib/typeprof/core/ast/meta.rb
+++ b/lib/typeprof/core/ast/meta.rb
@@ -66,6 +66,12 @@ module TypeProf::Core
       def opt_keywords = []
       def rest_keywords = nil
 
+      def mname_code_range(name)
+        idx = @args.index(name.to_sym) # TODO: support string args
+        node = @raw_node.arguments.arguments[idx].location
+        TypeProf::CodeRange.from_node(node)
+      end
+
       def install0(genv)
         @args.each do |arg|
           ivar_name = "@#{ arg }".to_sym # TODO: use DSYM
@@ -90,6 +96,12 @@ module TypeProf::Core
       attr_reader :args
 
       def attrs = { args: }
+
+      def mname_code_range(name)
+        idx = @args.index(name.to_sym) # TODO: support string args
+        node = @raw_node.arguments.arguments[idx].location
+        TypeProf::CodeRange.from_node(node)
+      end
 
       def define0(genv)
         @args.map do |arg|

--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -169,12 +169,13 @@ module TypeProf::Core
           end
           boxes << box if boxes.empty?
           boxes.each do |box|
-            box.resolve(genv, nil) do |me, _ty, _mid, _orig_ty|
+            box.resolve(genv, nil) do |me, _ty, mid, _orig_ty|
               next unless me
               me.defs.each do |mdef|
                 code_range =
                   case mdef.node
                   when AST::DefNode then mdef.node.mid_code_range
+                  when AST::AttrReaderMetaNode, AST::AttrAccessorMetaNode then mdef.node.mname_code_range(mid)
                   else mdef.node.code_range
                   end
 

--- a/scenario/service/definition.rb
+++ b/scenario/service/definition.rb
@@ -2,7 +2,8 @@
 class Foo
   BAR = 1
 
-  attr_reader :bar, :baz
+  attr_reader :bar_sym_reader, :baz_sym_reader
+  attr_accessor :bar_sym_accessor, :baz_sym_accessor
 
   def initialize(n)
     @bar = n
@@ -13,8 +14,10 @@ class Foo
 end
 
 Foo.new(1).foo(1.0)
-Foo.new(1).bar
-Foo.new(1).baz
+Foo.new(1).bar_sym_reader
+Foo.new(1).baz_sym_reader
+Foo.new(1).bar_sym_accessor
+Foo.new(1).baz_sym_accessor
 Foo::BAR
 Foo::BBAR = 1
 Foo::BBAR
@@ -22,29 +25,35 @@ Foo::CCAR, Foo::DDAR = [1, 2]
 Foo::CCAR
 Foo::DDAR
 
-## definition: test.rb:14:1
+## definition: test.rb:15:1
 test.rb:(1,6)-(1,9) # Jump to Foo class
 
-## definition: test.rb:14:5
-test.rb:(6,6)-(6,16) # Jump Foo.initialize from Foo.new
-
-## definition: test.rb:14:12
-test.rb:(10,6)-(10,9) # Jump to Foo#foo
+## definition: test.rb:15:5
+test.rb:(7,6)-(7,16) # Jump Foo.initialize from Foo.new
 
 ## definition: test.rb:15:12
-test.rb:(4,2)-(4,24) # Jump to Foo#bar (first arg of attr_reader)
+test.rb:(11,6)-(11,9) # Jump to Foo#foo
 
 ## definition: test.rb:16:12
-test.rb:(4,2)-(4,24) # Jump to Foo#baz (second arg of attr_reader)
+test.rb:(4,14)-(4,29) # Jump to Foo#bar_sym_reader (first sym arg of attr_reader)
 
-## definition: test.rb:17:5
+## definition: test.rb:17:12
+test.rb:(4,31)-(4,46) # Jump to Foo#baz_sym_reader (second sym arg of attr_reader)
+
+## definition: test.rb:18:12
+test.rb:(5,16)-(5,33) # Jump to Foo#bar_sym_accessor (first sym arg of attr_accessor)
+
+## definition: test.rb:19:12
+test.rb:(5,35)-(5,52) # Jump to Foo#baz_sym_accessor (second sym arg of attr_accessor)
+
+## definition: test.rb:20:5
 test.rb:(2,2)-(2,5) # Jump to Foo#BAR (constant_write_node)
 
-## definition: test.rb:19:5
-test.rb:(18,0)-(18,9) # Jump to Foo#BBAR (constant_path_write_node)
-
-## definition: test.rb:21:5
-test.rb:(20,0)-(20,9) # Jump to Foo#BBAR (first arg of constant_path_target_node)
-
 ## definition: test.rb:22:5
-test.rb:(20,11)-(20,20) # Jump to Foo#BBAR (second arg of constant_path_target_node)
+test.rb:(21,0)-(21,9) # Jump to Foo#BBAR (constant_path_write_node)
+
+## definition: test.rb:24:5
+test.rb:(23,0)-(23,9) # Jump to Foo#BBAR (first arg of constant_path_target_node)
+
+## definition: test.rb:25:5
+test.rb:(23,11)-(23,20) # Jump to Foo#BBAR (second arg of constant_path_target_node)


### PR DESCRIPTION
SSIA

This PR introduce `mname_code_range` method to corresponding to definition.
if you don't care about it, I will refactor the way of DefNode's doing with same interface.