### PR TITLE
Add README.md for excited rubist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# TypeProf
+
+An experimental type-level Ruby interpreter for testing and understanding Ruby code.
+
+## Development
+
+1. Install Ruby 3.3 or later.
+2. Git clone this repository: `git clone https://github.com/ruby/typeprof.git`
+3. Install VSCode extension: `code --install-extension mame.ruby-typeprof`
+4. Open the repository in VSCode: `code typeprof`
+
+### Testing
+
+```sh
+$ bundle install
+$ bundle exec rake test
+```
+
+## More details
+
+https://speakerdeck.com/mame/good-first-issues-of-typeprof
+
+## LICENSE
+
+See [LICENSE](LICENSE) file.


### PR DESCRIPTION

As more people, like me, become interested in typeprof due to the presentation at RubyKaigi 2024, it's unfortunate that there's no README available. By adding a README, we hope that those who visit typeprof can work on good first issues.

ref: https://speakerdeck.com/mame/good-first-issues-of-typeprof