### PR TITLE
Initial support lambda node

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -179,6 +179,7 @@ module TypeProf::Core
       when :range_node then RangeNode.new(raw_node, lenv)
       when :array_node then ArrayNode.new(raw_node, lenv)
       when :hash_node then HashNode.new(raw_node, lenv)
+      when :lambda_node then LambdaNode.new(raw_node, lenv)
 
       # misc
       when :defined_node then DefinedNode.new(raw_node, lenv)

--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -250,5 +250,11 @@ module TypeProf::Core
         Source.new(Type::Hash.new(genv, literal_pairs, genv.gen_hash_type(unified_key, unified_val)))
       end
     end
+
+    class LambdaNode < TypeProf::Core::AST::Node
+      def install0(genv)
+        Source.new(genv.proc_type)
+      end
+    end
   end
 end

--- a/scenario/lambda/basic1.rb
+++ b/scenario/lambda/basic1.rb
@@ -1,0 +1,9 @@
+## update
+def foo
+  -> () { 1 }
+end
+
+## assert
+class Object
+  def foo: -> Proc
+end


### PR DESCRIPTION
Prior to this change, typeprof would crash on encountering code like:

```rb
def x = -> { 1 }
```

This was because typeprof did not yet support lambda. 
With this update, such lambda definitions are now recognized as `def x: -> Proc`. 
While the ideal scenario would be to infer the lambda's type directly (e.g., `^() -> Integer` as in RBS), this initial step addresses the crash issue and provides basic support.