### PR TITLE
Ensure service is reset after scenario test failures

### DIFF
--- a/test/scenario_compiler.rb
+++ b/test/scenario_compiler.rb
@@ -34,7 +34,7 @@ class ScenarioCompiler
     @file = "test.rb"
     @pos = [0, 0]
     out = %(eval(<<'TYPEPROF_SCENARIO_END', nil, #{ scenario.dump }, 1)\n)
-    out << %(test(#{ scenario.dump }) {)
+    out << %(test(#{ scenario.dump }) do )
     unless @fast
       out << "core = TypeProf::Core::Service.new;"
     end
@@ -76,9 +76,9 @@ class ScenarioCompiler
         end
       END
     else
-      out << "core.reset!\n"
+      out << "ensure core.reset!\n"
     end
-    out << "}\n"
+    out << "end\n"
     out << %(TYPEPROF_SCENARIO_END\n)
   end
 


### PR DESCRIPTION
This PR fixes a bug in scenario_compiler.rb where `core.reset!` is not called when a test case fails. Due to this issue, one failing scenario can result in verbose failure messages that indicate irrelevant scenarios have also failed.

It seems that scenario_compiler.rb itself currently does not have test cases. While I have not added any in this PR, I will give it a try if requested.

## Reproduction procedure
- Add `scenario/a1.rb` with the following content.
```ruby
## update: test1.rb
f("a")

## assert
This is a wrong assertion.
```

- Add `scenario/a2.rb` with the following content.
```ruby
## update: test2.rb
def f(x) = nil
f(0)

## assert
class Object
  def f: (Integer) -> nil
end
```

- Run `rake test`.

### Expected Behavior
Only a1.rb fails.

### Actual Behavior (prior to this PR)
a2.rb also fails, due to the code introduced by a1.rb.

```
Failure: test: scenario/a2.rb(ScenarioCompiler::ScenarioTest)
scenario/a2.rb:5:in `block in <class:ScenarioTest>'
<"class Object\n" + "  def f: (Integer) -> nil\n" + "end"> expected but was
<"class Object\n" + "  def f: (Integer | String) -> nil\n" + "end">
```
