### PR TITLE
Support xstring

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -172,6 +172,8 @@ module TypeProf::Core
       when :symbol_node then SymbolNode.new(raw_node, lenv)
       when :interpolated_symbol_node then InterpolatedSymbolNode.new(raw_node, lenv)
       when :string_node then StringNode.new(raw_node, lenv, raw_node.content)
+      when :x_string_node then StringNode.new(raw_node, lenv, "")
+      when :interpolated_x_string_node then InterpolatedStringNode.new(raw_node, lenv)
       when :source_file_node then StringNode.new(raw_node, lenv, "")
       when :interpolated_string_node then InterpolatedStringNode.new(raw_node, lenv)
       when :regular_expression_node then RegexpNode.new(raw_node, lenv)

--- a/scenario/misc/dstr.rb
+++ b/scenario/misc/dstr.rb
@@ -18,3 +18,19 @@ class Object
   def bar: (Integer) -> String
   def qux: (Float) -> String
 end
+
+## update
+
+def xstring_lit(n)
+  `echo foo`
+end
+
+def interpolate_xstring
+  `echo #{xstring_lit(10)}`
+end
+
+## assert
+class Object
+  def xstring_lit: (Integer) -> String
+  def interpolate_xstring: -> String
+end


### PR DESCRIPTION
I supported xstring_node and interpolated_xstring_node

```ruby
`echo foo`
`echo #{xstring_lit(10)}`
```