### PR TITLE
Add singleton class to known-issues

### DIFF
--- a/scenario/known-issues/singleton-class.rb
+++ b/scenario/known-issues/singleton-class.rb
@@ -1,0 +1,11 @@
+## update
+class Foo
+  class << self
+    def foo = :ok
+  end
+end
+
+## assert
+class Foo
+  def self.foo: -> :ok
+end


### PR DESCRIPTION
Currently, we do not support `singleton_class_node`, which prevents us from handling syntax like the following:

```ruby
class Foo
  class << self
    def foo = :ok
  end
end
```

To address this as a known issue, I have added the corresponding test to known-issues.