### PR TITLE
Support keyword arguments support partially

### DIFF
--- a/lib/typeprof/core/ast/method.rb
+++ b/lib/typeprof/core/ast/method.rb
@@ -70,20 +70,16 @@ module TypeProf::Core
       opt_keywords = []
       opt_keyword_defaults = []
 
-      kw = raw_args.keywords
-      if false
-      while kw
-        raise unless kw.type == :KW_ARG
-        lasgn, kw = kw.children
-        var, expr = lasgn.children
-        if expr == :NODE_SPECIAL_REQUIRED_KEYWORD
-          req_keywords << var
-        else
-          opt_keywords << var
-          opt_keyword_defaults << AST.create_node(lasgn, lenv)
+      raw_args.keywords.each do |kw|
+        case kw.type
+        when :required_keyword_parameter_node
+          req_keywords << kw.name
+        when :optional_keyword_parameter_node
+          # TODO: support optional_keyword_parameter_node
         end
       end
 
+      if false
       rest_keywords = nil
       if args[8]
         raise unless args[8].type == :DVAR
@@ -146,8 +142,6 @@ module TypeProf::Core
         @opt_keyword_defaults = h[:opt_keyword_defaults]
         @rest_keywords = h[:rest_keywords]
         @block = h[:block]
-
-        # TODO: support opts, keywords, etc.
         @args_code_ranges = h[:args_code_ranges] || []
       end
 

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -479,7 +479,11 @@ module TypeProf::Core
       @f_args.post_positionals.each do |var|
         args << Type.strip_parens(var.show)
       end
-      # TODO: keywords
+      @f_args.req_keywords.each do |f_vtx|
+        # `f_vtx.show_name[4..]` means 'var:x' => 'x'
+        args << "#{f_vtx.show_name[4..]}: #{Type.strip_parens(f_vtx.show)}"
+      end
+      # TODO: support opt_keywords
       args = args.join(", ")
       s = args.empty? ? [] : ["(#{ args })"]
       s << "#{ block_show.sort.join(" | ") }" unless block_show.empty?

--- a/scenario/method/keywords.rb
+++ b/scenario/method/keywords.rb
@@ -1,0 +1,9 @@
+## update
+def foo(x:)
+  x
+end
+
+## assert
+class Object
+  def foo: (x: untyped) -> untyped
+end


### PR DESCRIPTION
Previously, methods defined with keyword arguments would have their keyword arguments ignored.

```rb
def foo(x:)
  x.to_i
end
```

→

```
def foo: -> Integer
```

With the added support for keyword arguments, keyword arguments can now be interpreted.
However, the following are not yet supported

- Method calls with keyword arguments
  keyword_hash_node because it does not support.
- Optional keyword arguments
  The scenario test `RuntimeError: AST diff does not work well; the completely same code generates a different AST` is annoying me and I gave up.