### PR TITLE
Add a scenario for definition jumps in multibyte characters

### DIFF
--- a/scenario/known-issues/definition_multibyte_characters.rb
+++ b/scenario/known-issues/definition_multibyte_characters.rb
@@ -1,0 +1,20 @@
+## update: test.rb
+module A動物
+  class B猫
+    def call
+      puts "にゃー"
+    end
+  end
+end
+
+A動物::B猫
+A動物::B猫.new.call
+
+## definition: test.rb:9:1
+test.rb:(1,7)-(1,10) # Jump to module
+
+## definition: test.rb:10:6
+test.rb:(2,8)-(2,10) # Jump to class
+
+## definition: test.rb:10:13
+test.rb:(3,8)-(3,12) # Jump to #call method


### PR DESCRIPTION
We discovered an issue where definition jumps do not work correctly when files contain multibyte characters. To address this, we have added scenario tests.

Additionally, as shown in the image below, it appears that hover functionality is also not functioning correctly with multibyte characters:
![CleanShot 2024-05-20 at 20 17 25](https://github.com/ruby/typeprof/assets/8983747/3f669770-df68-4f3b-aba6-af851e542f0b)

In contrast, the hover functionality works correctly without multibyte characters:
![CleanShot 2024-05-20 at 20 17 37](https://github.com/ruby/typeprof/assets/8983747/78350033-0345-40c6-afac-df0f0ae3ecf0)

Both examples above show the state when hovering over the ﻿`c` in `﻿.call`.