### PR TITLE
Add settings for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ruby
+{
+	"name": "typeprof",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/ruby:1-3.3-bookworm",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "ruby --version",
+
+	"onCreateCommand": "gem install rbs",
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"typeprof.server.path": "/workspaces/typeprof/bin/typeprof",
+				"files.associations": {
+					"typeprof.conf.json": "jsonc"
+				  }
+			},
+			"extensions": [
+				"mame.ruby-typeprof"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly


### PR DESCRIPTION
## Summary

GitHub Codespaces allows Ruby engineers to easily launch an environment to play with TypeProf.

This commit adds the files necessary to use GitHub Codespaces.

## Description

I created configuration files according to the documentation below.
refs: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers#using-a-predefined-dev-container-configuration

I followed the steps in this doc and used Ruby from the list of predefined dev container configurations. The changes made from the default settings are as follows.

- Add `rbs` because the `ruby:1-3.3-bookworm` image does not have rbs by default
- Add `mame.ruby-typeprof` extension and set `typeprof.server.path`
- Associate `typeprof.conf.json` with `jsonc`

## Other Information

A personal GitHub account includes 120 hours per month of Codespaces usage.
For more information, see the following.
refs: https://docs.github.com/en/billing/managing-billing-for-github-codespaces/about-billing-for-github-codespaces
