### PR TITLE
Support RBS attribute definitions

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -300,6 +300,12 @@ module TypeProf::Core
       when RBS::AST::Members::Private
       when RBS::AST::Members::Alias
         SigAliasNode.new(raw_decl, lenv)
+      when RBS::AST::Members::AttrReader
+        SigAttrReaderNode.new(raw_decl, lenv)
+      when RBS::AST::Members::AttrWriter
+        SigAttrWriterNode.new(raw_decl, lenv)
+      when RBS::AST::Members::AttrAccessor
+        SigAttrAccessorNode.new(raw_decl, lenv)
       when RBS::AST::Declarations::Base
         self.create_rbs_decl(raw_decl, lenv)
       else

--- a/scenario/rbs/attr.rb
+++ b/scenario/rbs/attr.rb
@@ -1,0 +1,38 @@
+## update: test.rbs
+class A
+  attr_reader foo: Integer
+  attr_writer foo: Integer | Float
+
+  attr_accessor bar: String
+end
+
+## update: test.rb
+def test1
+  a = A.new
+  a.foo = 42.0
+  a.foo
+end
+
+def test2
+  a = A.new
+  a.bar = "foo"
+  a.bar
+end
+
+## assert: test.rb
+class Object
+  def test1: -> Integer
+  def test2: -> String
+end
+
+## hover: test.rb:3:4
+A#foo= : (::Integer | ::Float) -> ::Integer | ::Float
+
+## hover: test.rb:4:4
+A#foo : -> ::Integer
+
+## hover: test.rb:9:4
+A#bar= : (::String) -> ::String
+
+## hover: test.rb:10:4
+A#bar : -> ::String


### PR DESCRIPTION
This PR adds support for RBS's `attr_reader`, `attr_writer`, and `attr_accessor` type definitions. Their expected behavior in TypeProf appears to be the same as regular method `def`s, so I used `add_method_decl_box` for them.

Side notes:
- I believe the return type of `A#foo=` in the added scenario should be parenthesized as `A#foo= : (::Integer | ::Float) -> (::Integer | ::Float)`. If you agree, I can address this in a separate PR.
- This PR introduces calls with keyword arguments, which currently makes dogfooding impossible. I'm not entirely sure, but wrapping such pieces of code in `eval` might be a solution. Should I proceed with that?