### PR TITLE
Support optional/rest keyword arguments for method definition

### DIFF
--- a/lib/typeprof/core/ast/method.rb
+++ b/lib/typeprof/core/ast/method.rb
@@ -80,15 +80,10 @@ module TypeProf::Core
         end
       end
 
-      if false
-      rest_keywords = nil
-      if args[8]
-        raise unless args[8].type == :DVAR
-        rest_keywords = args[8].children[0]
+      if raw_args.keyword_rest
+        rest_keywords = raw_args.keyword_rest.name
       end
 
-      block = args[9]
-      end
       block = raw_args.block.name if raw_args.block
 
       {

--- a/lib/typeprof/core/ast/method.rb
+++ b/lib/typeprof/core/ast/method.rb
@@ -75,7 +75,8 @@ module TypeProf::Core
         when :required_keyword_parameter_node
           req_keywords << kw.name
         when :optional_keyword_parameter_node
-          # TODO: support optional_keyword_parameter_node
+          opt_keywords << kw.name
+          opt_keyword_defaults << AST.create_node(kw.value, lenv)
         end
       end
 
@@ -177,7 +178,6 @@ module TypeProf::Core
         post_positionals:,
         req_keywords:,
         opt_keywords:,
-        opt_keyword_defaults:,
         rest_keywords:,
         block:,
       }

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -487,6 +487,9 @@ module TypeProf::Core
           args << "?#{ name }: #{Type.strip_parens(f_vtx.show)}"
         end
       end
+      if @f_args.rest_keywords
+        args << "**#{ Type.strip_parens(@f_args.rest_keywords.show) }"
+      end
       args = args.join(", ")
       s = args.empty? ? [] : ["(#{ args })"]
       s << "#{ block_show.sort.join(" | ") }" unless block_show.empty?

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -479,11 +479,14 @@ module TypeProf::Core
       @f_args.post_positionals.each do |var|
         args << Type.strip_parens(var.show)
       end
-      @f_args.req_keywords.each do |f_vtx|
-        # `f_vtx.show_name[4..]` means 'var:x' => 'x'
-        args << "#{f_vtx.show_name[4..]}: #{Type.strip_parens(f_vtx.show)}"
+      if @node.is_a?(AST::DefNode)
+        @node.req_keywords.zip(@f_args.req_keywords) do |name, f_vtx|
+          args << "#{ name }: #{Type.strip_parens(f_vtx.show)}"
+        end
+        @node.opt_keywords.zip(@f_args.opt_keywords) do |name, f_vtx|
+          args << "?#{ name }: #{Type.strip_parens(f_vtx.show)}"
+        end
       end
-      # TODO: support opt_keywords
       args = args.join(", ")
       s = args.empty? ? [] : ["(#{ args })"]
       s << "#{ block_show.sort.join(" | ") }" unless block_show.empty?

--- a/scenario/method/keywords.rb
+++ b/scenario/method/keywords.rb
@@ -27,3 +27,13 @@ end
 class Object
   def foo: (y: untyped, ?x: Integer) -> Integer
 end
+
+## update
+def foo(**kw)
+  kw
+end
+
+## assert
+class Object
+  def foo: (**untyped) -> untyped
+end

--- a/scenario/method/keywords.rb
+++ b/scenario/method/keywords.rb
@@ -7,3 +7,23 @@ end
 class Object
   def foo: (x: untyped) -> untyped
 end
+
+## update
+def foo(x: 1)
+  x
+end
+
+## assert
+class Object
+  def foo: (?x: Integer) -> Integer
+end
+
+## update
+def foo(x: 1, y:)
+  x
+end
+
+## assert
+class Object
+  def foo: (y: untyped, ?x: Integer) -> Integer
+end


### PR DESCRIPTION
This allows:

```ruby
def foo(req_kw:, opt_kw: 1, **rest_kws)
end
```

Passing keyword arguments is not supported yet, though.

Follow up of #182
