### PR TITLE
Support match_last_line_node and interpolated_match_last_line_node

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -180,6 +180,8 @@ module TypeProf::Core
       when :interpolated_string_node then InterpolatedStringNode.new(raw_node, lenv)
       when :regular_expression_node then RegexpNode.new(raw_node, lenv)
       when :interpolated_regular_expression_node then InterpolatedRegexpNode.new(raw_node, lenv)
+      when :match_last_line_node then MatchLastLineNode.new(raw_node, lenv)
+      when :interpolated_match_last_line_node then InterpolatedMatchLastLineNode.new(raw_node, lenv)
       when :range_node then RangeNode.new(raw_node, lenv)
       when :array_node then ArrayNode.new(raw_node, lenv)
       when :hash_node then HashNode.new(raw_node, lenv)

--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -169,6 +169,42 @@ module TypeProf::Core
       end
     end
 
+    class MatchLastLineNode < Node
+      def initialize(raw_node, lenv)
+        super(raw_node, lenv)
+      end
+
+      def install0(genv) = Source.new(genv.regexp_type)
+    end
+
+    class InterpolatedMatchLastLineNode < Node
+      def initialize(raw_node, lenv)
+        super(raw_node, lenv)
+        @parts = []
+        raw_node.parts.each do |raw_part|
+          case raw_part.type
+          when :string_node
+            @parts << AST.create_node(raw_part, lenv)
+          when :embedded_statements_node
+            @parts << AST.create_node(raw_part.statements, lenv)
+          else
+            raise "unknown regexp part: #{ raw_part.type }"
+          end
+        end
+      end
+
+      attr_reader :parts
+
+      def subnodes = { parts: }
+
+      def install0(genv)
+        @parts.each do |subnode|
+          subnode.install(genv)
+        end
+        Source.new(genv.regexp_type)
+      end
+    end
+
     class RangeNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)

--- a/scenario/misc/regexp.rb
+++ b/scenario/misc/regexp.rb
@@ -5,9 +5,17 @@ end
 def check2
   /foo#{ 1 }bar/
 end
+def check3
+  if /foo/ then end
+end
+def check4
+  if /foo#{ 1 }/ then end
+end
 
 ## assert
 class Object
   def check1: -> Regexp
   def check2: -> Regexp
+  def check3: -> nil
+  def check4: -> nil
 end


### PR DESCRIPTION
In prism, conditional statements that are passed only RegExp is parsed as `MatchLastLineNode`/`InterpolatedMatchLastLineNode`. related: https://github.com/ruby/prism/pull/1442

Those nodes are now supported in this PR.

We almost never use the `$LAST_READ_LINE` + `if RegExp` feature, but in the process of editing the code, it may be parsed to those node.