### PR TITLE
Implement `SourceEncodingNode`

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -177,6 +177,7 @@ module TypeProf::Core
       when :interpolated_x_string_node then InterpolatedStringNode.new(raw_node, lenv)
       when :source_file_node then StringNode.new(raw_node, lenv, "")
       when :source_line_node then IntegerNode.new(raw_node, lenv, 0)
+      when :source_encoding_node then SourceEncodingNode.new(raw_node, lenv)
       when :interpolated_string_node then InterpolatedStringNode.new(raw_node, lenv)
       when :regular_expression_node then RegexpNode.new(raw_node, lenv)
       when :interpolated_regular_expression_node then InterpolatedRegexpNode.new(raw_node, lenv)

--- a/lib/typeprof/core/ast/misc.rb
+++ b/lib/typeprof/core/ast/misc.rb
@@ -98,5 +98,11 @@ module TypeProf::Core
         Source.new(genv.true_type, genv.false_type)
       end
     end
+
+    class SourceEncodingNode < Node
+      def install0(genv)
+        Source.new(Type::Instance.new(genv, genv.resolve_cpath([:Encoding]), []))
+      end
+    end
   end
 end

--- a/scenario/misc/source_encoding.rb
+++ b/scenario/misc/source_encoding.rb
@@ -1,0 +1,9 @@
+## update
+def foo
+  __ENCODING__
+end
+
+## assert
+class Object
+  def foo: -> Encoding
+end


### PR DESCRIPTION
Added support for SourceEncodingNode.

There was a problem with resolving classes included in the standard library, but I took an ad hoc solution for the time being.