### PR TITLE
Add a known issues scenario for argv

### DIFF
--- a/scenario/known-issues/argv.rb
+++ b/scenario/known-issues/argv.rb
@@ -1,0 +1,11 @@
+## update
+def foo(n)
+  n.to_s
+end
+
+foo(ARGV[0].to_i)
+
+## assert
+class Object
+  def foo: (Integer) -> String
+end


### PR DESCRIPTION
I added a scenario to the known issues because, when passing arguments via ARGV and explicitly converting them with to_s or to_i, they still remain untyped.

```rb
def foo(n)
  n.to_s
end

foo(ARGV[0].to_i)
```

### Test Results

```
Failure: test: scenario/known-issues/argv.rb(ScenarioCompiler::ScenarioTest)
scenario/known-issues/argv.rb:8:in 'block in <class:ScenarioTest>'
<"class Object\n" + "  def foo: (Integer) -> String\n" + "end"> expected but was
<"class Object\n" + "  def foo: (untyped) -> untyped\n" + "end">
```