### PR TITLE
Make MatchLastLineNode return a bool type

### DIFF
--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -174,7 +174,7 @@ module TypeProf::Core
         super(raw_node, lenv)
       end
 
-      def install0(genv) = Source.new(genv.regexp_type)
+      def install0(genv) = Source.new(genv.true_type, genv.false_type)
     end
 
     class InterpolatedMatchLastLineNode < Node
@@ -201,7 +201,7 @@ module TypeProf::Core
         @parts.each do |subnode|
           subnode.install(genv)
         end
-        Source.new(genv.regexp_type)
+        Source.new(genv.true_type, genv.false_type)
       end
     end
 

--- a/scenario/misc/regexp.rb
+++ b/scenario/misc/regexp.rb
@@ -6,16 +6,24 @@ def check2
   /foo#{ 1 }bar/
 end
 def check3
-  if /foo/ then end
+  if /foo/
+    :then
+  else
+    :else
+  end
 end
 def check4
-  if /foo#{ 1 }/ then end
+  if /foo#{ 1 }/
+    :then
+  else
+    :else
+  end
 end
 
 ## assert
 class Object
   def check1: -> Regexp
   def check2: -> Regexp
-  def check3: -> nil
-  def check4: -> nil
+  def check3: -> (:else | :then)
+  def check4: -> (:else | :then)
 end


### PR DESCRIPTION
... instead of a Regexp type.

This change is not a very important at present. But giving a regexp type to a conditional expression may be handled by a future flow-analysis, so I'd like to ensure that `foo` in `if /foo` should return `true|false`.

Follow up of #193.