### PR TITLE
Support `return x, y`

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -274,8 +274,16 @@ module TypeProf::Core
     class ReturnNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
-        # TODO: return x, y
-        @arg = raw_node.arguments ? AST.create_node(raw_node.arguments.arguments.first, lenv) : DummyNilNode.new(code_range, lenv)
+        if raw_node.arguments
+          elems = raw_node.arguments.arguments
+          if elems.one?
+            @arg = AST.create_node(elems.first, lenv)
+          else
+            @arg = DummyArrayNode.new(elems, code_range, lenv)
+          end
+        else
+          @arg = DummyNilNode.new(code_range, lenv)
+        end
       end
 
       attr_reader :arg

--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -227,7 +227,7 @@ module TypeProf::Core
     class ArrayNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
-        @elems = raw_node.elements.map {|n| AST.create_node(n, lenv) }
+        @elems ||= raw_node.elements.map {|n| AST.create_node(n, lenv) }
       end
 
       attr_reader :elems
@@ -296,6 +296,14 @@ module TypeProf::Core
     class ImaginaryNode < TypeProf::Core::AST::Node
       def install0(genv)
         Source.new(genv.complex_type)
+      end
+    end
+
+    class DummyArrayNode < ArrayNode
+      def initialize(elements, code_range, lenv)
+        @elems = elements.map {|n| AST.create_node(n, lenv) }
+        @code_range = code_range
+        super(nil, lenv)
       end
     end
   end

--- a/scenario/control/return2.rb
+++ b/scenario/control/return2.rb
@@ -1,0 +1,9 @@
+## update
+def foo
+  return 1, 2
+end
+
+## assert
+class Object
+  def foo: -> [Integer, Integer]
+end


### PR DESCRIPTION
Proposal: Support `return x, y`.

This change introduces the new class `DummyArrayNode`, which treats `return x, y` as `return [x, y]`.