### PR TITLE
Render positional arguments defined in RBS with hover

### DIFF
--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -225,12 +225,18 @@ module TypeProf::Core
         method_type.req_positionals.each do |arg|
           args << arg.show
         end
-        # TODO
-        method_type.opt_positionals
-        method_type.rest_positionals
-        method_type.post_positionals
-        # method_type.req_keywords
-        # method_type.req_keywords
+        method_type.opt_positionals.each do |arg|
+          args << "?#{arg.show}"
+        end
+        method_type.post_positionals.each do |arg|
+          args << arg.show
+        end
+        if method_type.rest_positionals
+          args << "*#{method_type.rest_positionals.show}"
+        end
+
+        # TODO: req_keywords, opt_keywords, rest_keywords
+
         s = args.empty? ? "-> " : "(#{ args.join(", ") }) -> "
         s += method_type.return_type.show
       end.join(" | ")

--- a/scenario/service/hover4.rb
+++ b/scenario/service/hover4.rb
@@ -1,0 +1,28 @@
+## update: test.rbs
+class Object
+  def required_positional_args: (Integer) -> Integer
+
+  def optional_positional_args: (?Integer) -> Integer
+
+  def post_required_positional_args: (?Integer, Integer) -> Integer
+
+  def rest_positional_args: (*Integer) -> Integer
+end
+
+## update: test.rb
+required_positional_args
+optional_positional_args
+post_required_positional_args
+rest_positional_args
+
+## hover: test.rb:1:1
+Object#required_positional_args : (::Integer) -> ::Integer
+
+## hover: test.rb:2:1
+Object#optional_positional_args : (?::Integer) -> ::Integer
+
+## hover: test.rb:3:1
+Object#post_required_positional_args : (?::Integer, ::Integer) -> ::Integer
+
+## hover: test.rb:4:1
+Object#rest_positional_args : (*::Integer) -> ::Integer


### PR DESCRIPTION
The following are newly supported.

- Optional positional arguments
- Rest positional arguments
- Post positional arguments

NOTE: The keyword argument requires a change in `sig_type.rb`. I will change it in next PR.