### PR TITLE
Partial support for passing keyword arguments to CallNode

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -223,6 +223,7 @@ module TypeProf::Core
           end
         end
         CallNode.new(raw_node, lenv)
+      when :keyword_hash_node then KeywordHashNode.new(raw_node, lenv)
       else
         pp raw_node
         raise "not supported yet: #{ raw_node.type }"

--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -199,7 +199,8 @@ module TypeProf::Core
       when :interpolated_match_last_line_node then InterpolatedMatchLastLineNode.new(raw_node, lenv)
       when :range_node then RangeNode.new(raw_node, lenv)
       when :array_node then ArrayNode.new(raw_node, lenv)
-      when :hash_node then HashNode.new(raw_node, lenv)
+      when :hash_node then HashNode.new(raw_node, lenv, false)
+      when :keyword_hash_node then HashNode.new(raw_node, lenv, true)
       when :lambda_node then LambdaNode.new(raw_node, lenv)
       when :imaginary_node then ImaginaryNode.new(raw_node, lenv)
 
@@ -223,7 +224,6 @@ module TypeProf::Core
           end
         end
         CallNode.new(raw_node, lenv)
-      when :keyword_hash_node then KeywordHashNode.new(raw_node, lenv)
       else
         pp raw_node
         raise "not supported yet: #{ raw_node.type }"

--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -32,12 +32,11 @@ module TypeProf::Core
           end
           @positional_args = args.map {|arg| AST.create_node(arg, lenv) }
 
-          #last_hash_arg = @positional_args.last
-          #if last_hash_arg.is_a?(HashNode) && last_hash_arg.keywords
-          #  @positional_args.pop
-          #  @keyword_args = last_hash_arg
-          #end
+          if @positional_args.last.is_a?(TypeProf::Core::AST::HashNode) && @positional_args.last.keywords
+            @keyword_args = @positional_args.pop
+          end
         end
+
         @positional_args << last_arg if last_arg
 
         if raw_block

--- a/lib/typeprof/core/env/method.rb
+++ b/lib/typeprof/core/env/method.rb
@@ -36,7 +36,7 @@ module TypeProf::Core
     def new_vertexes(genv, name, node)
       positionals = @positionals.map {|arg| arg.new_vertex(genv, "arg:#{ name }", node) }
       splat_flags = @splat_flags
-      keywords = @keywords # TODO
+      keywords = @keywords ? @keywords.new_vertex(genv, "kw:#{ name }", node) : nil
       block = @block ? @block.new_vertex(genv, "block:#{ name }", node) : nil
       ActualArguments.new(positionals, splat_flags, keywords, block)
     end

--- a/scenario/known-issues/keywords.rb
+++ b/scenario/known-issues/keywords.rb
@@ -1,8 +1,11 @@
 ## update
-def foo(x: 1)
-  x
+def foo(a)
+  a
 end
 
-foo(x: "str")
+foo(x: 1)
 
 ## assert
+class Object
+  def foo: (Hash[:x, Integer]) -> Hash[:x, Integer]
+end

--- a/scenario/method/keywords.rb
+++ b/scenario/method/keywords.rb
@@ -37,3 +37,39 @@ end
 class Object
   def foo: (**untyped) -> untyped
 end
+
+## update
+def foo(x:)
+  x
+end
+
+foo(x: "str")
+
+## assert
+class Object
+  def foo: (x: String) -> String
+end
+
+## update
+def foo(x: 1)
+  x
+end
+
+foo(x: "str")
+
+## assert
+class Object
+  def foo: (?x: Integer | String) -> (Integer | String)
+end
+
+## update
+def foo(a:, b: 1, **c)
+  c
+end
+
+foo(a: '', b: 1, c: true)
+
+## assert
+class Object
+  def foo: (a: String, ?b: Integer, **Hash[:a | :b | :c, Integer | String | true]) -> Hash[:a | :b | :c, Integer | String | true]
+end


### PR DESCRIPTION
Support KeywordHashNode and resolving basic keyword argument calls.

I have confirmed that it works in a simple case, but it is probably still incomplete.
However, it will be better than the current behavior where an exception is raised by a call to a keyword arguments.
