### PR TITLE
Support `next x, y`

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -186,8 +186,16 @@ module TypeProf::Core
     class NextNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
-        # TODO: next 1, 2
-        @arg = raw_node.arguments ? AST.create_node(raw_node.arguments.arguments.first, lenv) : DummyNilNode.new(code_range, lenv)
+        if raw_node.arguments
+          if raw_node.arguments.arguments.one?
+            @arg = AST.create_node(raw_node.arguments.arguments.first, lenv)
+          else
+            elems = raw_node.arguments.arguments
+            @arg = DummyArrayNode.new(elems, code_range, lenv)
+          end
+        else
+          @arg = DummyNilNode.new(code_range, lenv)
+        end
       end
 
       attr_reader :arg

--- a/scenario/control/next3.rb
+++ b/scenario/control/next3.rb
@@ -1,0 +1,14 @@
+## update
+def foo
+  yield 42
+end
+
+foo do |n|
+  next 1, 2
+  "str"
+end
+
+## assert
+class Object
+  def foo: { (Integer) -> (String | [Integer, Integer]) } -> (String | [Integer, Integer])
+end


### PR DESCRIPTION
Similar to https://github.com/ruby/typeprof/pull/200, I thought it would be possible to implement the `next x, y` pattern using the DummyArrayNode added in https://github.com/ruby/typeprof/pull/200. How about that?

