### PR TITLE
Support `$1` ~ `$9`

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -149,6 +149,8 @@ module TypeProf::Core
         read = GlobalVariableReadNode.new(raw_node, lenv)
         rhs = AndNode.new(raw_node, read, raw_node.value, lenv)
         GlobalVariableWriteNode.new(raw_node, rhs, lenv)
+      when :numbered_reference_read_node
+        NumberedReferenceReadNode.new(raw_node, lenv)
 
       # assignment targets
       when :index_operator_write_node

--- a/lib/typeprof/core/ast/variable.rb
+++ b/lib/typeprof/core/ast/variable.rb
@@ -247,5 +247,21 @@ module TypeProf::Core
         yield self if code_range.include?(pos)
       end
     end
+
+    class NumberedReferenceReadNode < Node
+      def initialize(raw_node, lenv)
+        super(raw_node, lenv)
+        @var = :"$#{raw_node.number}"
+      end
+
+      attr_reader :var
+
+      def attrs = { var: }
+
+      def install0(genv)
+        box = @changes.add_gvar_read_box(genv, @var)
+        box.ret
+      end
+    end
   end
 end

--- a/scenario/known-issues/nth_group_of_last_match.rb
+++ b/scenario/known-issues/nth_group_of_last_match.rb
@@ -1,0 +1,9 @@
+## update
+def nth_group_greater_than_9_of_last_match
+  $10
+end
+
+## assert
+class Object
+  def nth_group_greater_than_9_of_last_match: -> String?
+end

--- a/scenario/variable/gvar.rb
+++ b/scenario/variable/gvar.rb
@@ -11,9 +11,14 @@ def baz
   $VERBOSE
 end
 
+def nth_group_of_last_match
+  [$1, $2, $3, $4, $5, $6, $7, $8, $9]
+end
+
 ## assert
 class Object
   def foo: -> String
   def bar: -> String
   def baz: -> bool?
+  def nth_group_of_last_match: -> [String?, String?, String?, String?, String?, String?, String?, String?, String?]
 end


### PR DESCRIPTION
Support for NumberedReferenceReadNode to handle `$1` ~ `$9`. Variables `$1` to `$9` are resolved to `String?`, but `$10` and beyond are resolved to `untyped`. According to RBS, only between `$1` and `$9` are currently defined.

For more details, refer to the RBS core global variables definition.
https://github.com/ruby/rbs/blob/ec5a819/core/global_variables.rbs#L77-L105

To support `$10` and beyond, we need to either add the definitions to RBS or modify `NumberedReferenceReadNode#install0` to return `Source.new(genv.str_type, genv.nil_type).`