### PR TITLE
Fix an error when parsing `case` statement without predicate

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -225,7 +225,7 @@ module TypeProf::Core
     class CaseNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
-        @pivot = AST.create_node(raw_node.predicate, lenv)
+        @pivot = raw_node.predicate ? AST.create_node(raw_node.predicate, lenv) : nil
         @whens = []
         @clauses = []
         raw_node.conditions.each do |raw_cond|
@@ -241,7 +241,7 @@ module TypeProf::Core
 
       def install0(genv)
         ret = Vertex.new("case", self)
-        @pivot.install(genv)
+        @pivot&.install(genv)
         @whens.zip(@clauses) do |vals, clause|
           vals.install(genv)
           @changes.add_edge(genv, clause.install(genv), ret)

--- a/scenario/control/case.rb
+++ b/scenario/control/case.rb
@@ -38,10 +38,18 @@ def qux(n)
   end
 end
 
+def without_predicate(n)
+  case
+  when true
+    1
+  end
+end
+
 ## assert
 class Object
   def foo: (untyped) -> (Float | Integer | String)
   def bar: (untyped) -> (Integer | String)?
   def baz: (untyped) -> (Integer | String)
   def qux: (untyped) -> nil
+  def without_predicate: (untyped) -> Integer?
 end


### PR DESCRIPTION
I found that a `case` statement without a predicate throws an error, so I fixed it.