### PR TITLE
Make #parts non-destructive

### DIFF
--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -110,7 +110,7 @@ module TypeProf::Core
         super(raw_node, lenv)
         @parts = []
 
-        queue = raw_node.parts
+        queue = raw_node.parts.dup
 
         until queue.empty?
           raw_part = queue.shift


### PR DESCRIPTION
follow-up #218

I missed that`#parts` is `attr_reader`.
It was being destructively modified by `Array#shift`.