### PR TITLE
$1 returns String

### DIFF
--- a/lib/typeprof/core/ast/variable.rb
+++ b/lib/typeprof/core/ast/variable.rb
@@ -259,8 +259,7 @@ module TypeProf::Core
       def attrs = { var: }
 
       def install0(genv)
-        box = @changes.add_gvar_read_box(genv, @var)
-        box.ret
+        Source.new(genv.str_type)
       end
     end
   end

--- a/scenario/known-issues/nth_group_of_last_match.rb
+++ b/scenario/known-issues/nth_group_of_last_match.rb
@@ -1,9 +1,0 @@
-## update
-def nth_group_greater_than_9_of_last_match
-  $10
-end
-
-## assert
-class Object
-  def nth_group_greater_than_9_of_last_match: -> String?
-end

--- a/scenario/variable/gvar.rb
+++ b/scenario/variable/gvar.rb
@@ -12,7 +12,7 @@ def baz
 end
 
 def nth_group_of_last_match
-  [$1, $2, $3, $4, $5, $6, $7, $8, $9]
+  [$1, $2, $3, $4, $5, $6, $7, $8, $9, $10]
 end
 
 ## assert
@@ -20,5 +20,5 @@ class Object
   def foo: -> String
   def bar: -> String
   def baz: -> bool?
-  def nth_group_of_last_match: -> [String?, String?, String?, String?, String?, String?, String?, String?, String?]
+  def nth_group_of_last_match: -> [String, String, String, String, String, String, String, String, String, String]
 end


### PR DESCRIPTION
follow-up #216 

related: https://github.com/ruby/typeprof/pull/216#issuecomment-2160138592

> @mame
> BTW, I would like to make $1 return a String, not String?. String? is indeed "correct", but I think it is often inconvenient because it brings more false warnings than finding actual errors.
> This is because almost always when I write $1, I expect it to return a String (unless it is written as a condition, like if $1).
> So I think it would be good to make $<number> always return String.