### PR TITLE
Added support for SingletonClassNode

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -13,7 +13,7 @@ module TypeProf::Core
       Fiber[:comments] = result.comments
 
       cref = CRef::Toplevel
-      lenv = LocalEnv.new(path, cref, {}, [])
+      lenv = LocalEnv.new(path, cref, {}, [], nil)
 
       ProgramNode.new(raw_scope, lenv)
     end
@@ -39,6 +39,7 @@ module TypeProf::Core
       when :class_node then ClassNode.new(raw_node, lenv, use_result)
       when :def_node then DefNode.new(raw_node, lenv, use_result)
       when :alias_method_node then AliasNode.new(raw_node, lenv)
+      when :singleton_class_node then SingletonClassNode.new(raw_node, lenv)
 
       # control
       when :and_node then AndNode.new(raw_node, lenv)
@@ -283,7 +284,7 @@ module TypeProf::Core
       _buffer, _directives, raw_decls = RBS::Parser.parse_signature(src)
 
       cref = CRef::Toplevel
-      lenv = LocalEnv.new(path, cref, {}, [])
+      lenv = LocalEnv.new(path, cref, {}, [], nil)
 
       raw_decls.map do |raw_decl|
         AST.create_rbs_decl(raw_decl, lenv)

--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -37,9 +37,9 @@ module TypeProf::Core
       when :statements_node then StatementsNode.new(raw_node, lenv, use_result)
       when :module_node then ModuleNode.new(raw_node, lenv, use_result)
       when :class_node then ClassNode.new(raw_node, lenv, use_result)
+      when :singleton_class_node then SingletonClassNode.new(raw_node, lenv, use_result)
       when :def_node then DefNode.new(raw_node, lenv, use_result)
       when :alias_method_node then AliasNode.new(raw_node, lenv)
-      when :singleton_class_node then SingletonClassNode.new(raw_node, lenv)
 
       # control
       when :and_node then AndNode.new(raw_node, lenv)
@@ -258,7 +258,7 @@ module TypeProf::Core
       end
     end
 
-    def self.parse_cpath(raw_node, base_cpath)
+    def self.parse_cpath(raw_node, cref)
       names = []
       while raw_node
         case raw_node.type
@@ -273,11 +273,14 @@ module TypeProf::Core
           else
             return names.reverse
           end
+        when :self_node
+          break if cref.scope_level == :class
+          return nil
         else
           return nil
         end
       end
-      return base_cpath + names.reverse
+      return cref.cpath + names.reverse
     end
 
     def self.parse_rbs(path, src)

--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -13,7 +13,7 @@ module TypeProf::Core
       Fiber[:comments] = result.comments
 
       cref = CRef::Toplevel
-      lenv = LocalEnv.new(path, cref, {}, [], nil)
+      lenv = LocalEnv.new(path, cref, {}, [])
 
       ProgramNode.new(raw_scope, lenv)
     end
@@ -284,7 +284,7 @@ module TypeProf::Core
       _buffer, _directives, raw_decls = RBS::Parser.parse_signature(src)
 
       cref = CRef::Toplevel
-      lenv = LocalEnv.new(path, cref, {}, [], nil)
+      lenv = LocalEnv.new(path, cref, {}, [])
 
       raw_decls.map do |raw_decl|
         AST.create_rbs_decl(raw_decl, lenv)

--- a/lib/typeprof/core/ast/base.rb
+++ b/lib/typeprof/core/ast/base.rb
@@ -207,7 +207,7 @@ module TypeProf::Core
 
       def install0(genv)
         @tbl.each {|var| @lenv.locals[var] = Source.new(genv.nil_type) }
-        @lenv.locals[:"*self"] = Source.new(lenv.cref.get_self(genv))
+        @lenv.locals[:"*self"] = lenv.cref.get_self(genv)
 
         @body.install(genv)
       end

--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -56,8 +56,8 @@ module TypeProf::Core
                             else
                               raise "not supported yet: #{ raw_block.parameters.class }"
                             end
-            ncref = CRef.new(lenv.cref.cpath, false, @mid, lenv.cref)
-            nlenv = LocalEnv.new(@lenv.path, ncref, {}, @lenv.return_boxes, nil)
+            ncref = CRef.new(lenv.cref.cpath, :instance, @mid, lenv.cref)
+            nlenv = LocalEnv.new(@lenv.path, ncref, {}, @lenv.return_boxes)
             @block_body = raw_block.body ? AST.create_node(raw_block.body, nlenv) : DummyNilNode.new(code_range, lenv)
           end
         end
@@ -84,7 +84,7 @@ module TypeProf::Core
         if @block_body
           @lenv.locals.each {|var, vtx| @block_body.lenv.locals[var] = vtx }
           @block_tbl.each {|var| @block_body.lenv.locals[var] = Source.new(genv.nil_type) }
-          @block_body.lenv.locals[:"*self"] = Source.new(@block_body.lenv.cref.get_self(genv))
+          @block_body.lenv.locals[:"*self"] = @block_body.lenv.cref.get_self(genv)
 
           blk_f_args = []
           if @block_f_args

--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -57,7 +57,7 @@ module TypeProf::Core
                               raise "not supported yet: #{ raw_block.parameters.class }"
                             end
             ncref = CRef.new(lenv.cref.cpath, false, @mid, lenv.cref)
-            nlenv = LocalEnv.new(@lenv.path, ncref, {}, @lenv.return_boxes)
+            nlenv = LocalEnv.new(@lenv.path, ncref, {}, @lenv.return_boxes, nil)
             @block_body = raw_block.body ? AST.create_node(raw_block.body, nlenv) : DummyNilNode.new(code_range, lenv)
           end
         end

--- a/lib/typeprof/core/ast/const.rb
+++ b/lib/typeprof/core/ast/const.rb
@@ -66,12 +66,12 @@ module TypeProf::Core
         when :constant_path_write_node, :constant_path_operator_write_node, :constant_path_or_write_node, :constant_path_and_write_node
           # expr::C = expr
           @cpath = AST.create_node(raw_node.target, lenv)
-          @static_cpath = AST.parse_cpath(raw_node.target, lenv.cref.cpath)
+          @static_cpath = AST.parse_cpath(raw_node.target, lenv.cref)
           @cname_code_range = TypeProf::CodeRange.from_node(raw_node.target)
         when :constant_path_target_node
           # expr::C, * = ary
           @cpath = ConstantReadNode.new(raw_node, lenv)
-          @static_cpath = AST.parse_cpath(raw_node, lenv.cref.cpath)
+          @static_cpath = AST.parse_cpath(raw_node, lenv.cref)
           @cname_code_range = TypeProf::CodeRange.from_node(raw_node)
         else
           raise

--- a/lib/typeprof/core/ast/method.rb
+++ b/lib/typeprof/core/ast/method.rb
@@ -104,7 +104,7 @@ module TypeProf::Core
     class DefNode < Node
       def initialize(raw_node, lenv, use_result)
         super(raw_node, lenv)
-        singleton = !!raw_node.receiver
+        singleton = !!raw_node.receiver || !!lenv.implicit_receiver
         mid = raw_node.name
         mid_code_range = TypeProf::CodeRange.from_node(raw_node.name_loc)
         @tbl = raw_node.locals
@@ -118,7 +118,7 @@ module TypeProf::Core
         @mid_code_range = mid_code_range
 
         ncref = CRef.new(lenv.cref.cpath, @singleton, @mid, lenv.cref)
-        nlenv = LocalEnv.new(@lenv.path, ncref, {}, [])
+        nlenv = LocalEnv.new(@lenv.path, ncref, {}, [], nil)
         if raw_body
           @body = AST.create_node(raw_body, nlenv)
         else

--- a/lib/typeprof/core/ast/module.rb
+++ b/lib/typeprof/core/ast/module.rb
@@ -11,8 +11,8 @@ module TypeProf::Core
         # TODO: class Foo < Struct.new(:foo, :bar)
 
         if @static_cpath
-          ncref = CRef.new(@static_cpath, true, nil, lenv.cref)
-          nlenv = LocalEnv.new(@lenv.path, ncref, {}, [], nil)
+          ncref = CRef.new(@static_cpath, :class, nil, lenv.cref)
+          nlenv = LocalEnv.new(@lenv.path, ncref, {}, [])
           @body = raw_scope ? AST.create_node(raw_scope, nlenv, use_result) : DummyNilNode.new(code_range, lenv)
         else
           @body = nil
@@ -59,7 +59,7 @@ module TypeProf::Core
         @cpath.install(genv)
         if @static_cpath
           @tbl.each {|var| @body.lenv.locals[var] = Source.new(genv.nil_type) }
-          @body.lenv.locals[:"*self"] = Source.new(@body.lenv.cref.get_self(genv))
+          @body.lenv.locals[:"*self"] = @body.lenv.cref.get_self(genv)
 
           @mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@static_cpath)))
           @changes.add_edge(genv, @mod_val, @mod_cdef.vtx)
@@ -133,8 +133,8 @@ module TypeProf::Core
         if @static_cpath.nil? || @static_cpath.empty?
           @body = nil
         else
-          ncref = CRef.new(static_cpath, true, nil, lenv.cref)
-          nlenv = LocalEnv.new(lenv.path, ncref, {}, [], ncref)
+          ncref = CRef.new(static_cpath, :metaclass, nil, lenv.cref)
+          nlenv = LocalEnv.new(lenv.path, ncref, {}, [])
           @body = @raw_node.body ? AST.create_node(@raw_node.body, nlenv) : DummyNilNode.new(code_range, lenv)
         end
       end
@@ -179,7 +179,7 @@ module TypeProf::Core
 
         if @body
           @tbl.each {|var| @body.lenv.locals[var] = Source.new(genv.nil_type) }
-          @body.lenv.locals[:"*self"] = Source.new(@body.lenv.cref.get_self(genv))
+          @body.lenv.locals[:"*self"] = @body.lenv.cref.get_self(genv)
 
           @mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@static_cpath)))
           @changes.add_edge(genv, @mod_val, @mod_cdef.vtx)

--- a/lib/typeprof/core/ast/module.rb
+++ b/lib/typeprof/core/ast/module.rb
@@ -1,24 +1,24 @@
 module TypeProf::Core
   class AST
     class ModuleBaseNode < Node
-      def initialize(raw_node, lenv, raw_cpath, raw_scope, use_result)
+      def initialize(raw_node, lenv, raw_cpath, meta, raw_scope, use_result)
         super(raw_node, lenv)
 
         @cpath = AST.create_node(raw_cpath, lenv)
-        @static_cpath = AST.parse_cpath(raw_cpath, lenv.cref.cpath)
+        @static_cpath = AST.parse_cpath(raw_cpath, lenv.cref)
         @tbl = raw_node.locals
 
         # TODO: class Foo < Struct.new(:foo, :bar)
 
         if @static_cpath
-          ncref = CRef.new(@static_cpath, :class, nil, lenv.cref)
+          ncref = CRef.new(@static_cpath, meta ? :metaclass : :class, nil, lenv.cref)
           nlenv = LocalEnv.new(@lenv.path, ncref, {}, [])
           @body = raw_scope ? AST.create_node(raw_scope, nlenv, use_result) : DummyNilNode.new(code_range, lenv)
         else
           @body = nil
         end
 
-        @cname_code_range = TypeProf::CodeRange.from_node(raw_node.constant_path)
+        @cname_code_range = meta ? nil : TypeProf::CodeRange.from_node(raw_node.constant_path)
       end
 
       attr_reader :tbl, :cpath, :static_cpath, :cname_code_range, :body
@@ -78,13 +78,13 @@ module TypeProf::Core
 
     class ModuleNode < ModuleBaseNode
       def initialize(raw_node, lenv, use_result)
-        super(raw_node, lenv, raw_node.constant_path, raw_node.body, use_result)
+        super(raw_node, lenv, raw_node.constant_path, false, raw_node.body, use_result)
       end
     end
 
     class ClassNode < ModuleBaseNode
       def initialize(raw_node, lenv, use_result)
-        super(raw_node, lenv, raw_node.constant_path, raw_node.body, use_result)
+        super(raw_node, lenv, raw_node.constant_path, false, raw_node.body, use_result)
         raw_superclass = raw_node.superclass
         @superclass_cpath = raw_superclass ? AST.create_node(raw_superclass, lenv) : nil
       end
@@ -114,85 +114,9 @@ module TypeProf::Core
       end
     end
 
-    class SingletonClassNode < Node
-      def initialize(raw_node, lenv)
-        super(raw_node, lenv)
-
-        @expression = AST.create_node(raw_node.expression, lenv)
-        @tbl = raw_node.locals
-
-        @static_cpath = case @expression
-                        when ConstantReadNode
-                          AST.parse_cpath(@raw_node.expression, lenv.cref.cpath)
-                        when SelfNode
-                          lenv.cref.cpath
-                        else
-                          raise "unsupported expression: #{@expression}"
-                        end
-
-        if @static_cpath.nil? || @static_cpath.empty?
-          @body = nil
-        else
-          ncref = CRef.new(static_cpath, :metaclass, nil, lenv.cref)
-          nlenv = LocalEnv.new(lenv.path, ncref, {}, [])
-          @body = @raw_node.body ? AST.create_node(@raw_node.body, nlenv) : DummyNilNode.new(code_range, lenv)
-        end
-      end
-
-      attr_reader :expression, :tbl, :static_cpath, :body
-
-      def subnodes = { expression:, body: }
-      def attrs = { tbl:, static_cpath: }
-
-      def define0(genv)
-        @expression.define(genv)
-
-        if @body
-          @body.define(genv)
-          @mod = genv.resolve_cpath(@static_cpath)
-          @mod_cdef = @mod.add_module_def(genv, self)
-        else
-          @changes.add_diagnostic(:code_range, "TypeProf cannot analyze a non-static class") # warning
-          nil
-        end
-      end
-
-      def define_copy(genv)
-        if @body
-          @mod_cdef.add_def(self)
-          @mod_cdef.remove_def(@prev_node)
-        end
-        super(genv)
-      end
-
-      def undefine0(genv)
-        if @body
-          @mod.remove_module_def(genv, self)
-          @body.undefine(genv)
-        end
-
-        @expression.undefine(genv)
-      end
-
-      def install0(genv)
-        @expression.install(genv)
-
-        if @body
-          @tbl.each {|var| @body.lenv.locals[var] = Source.new(genv.nil_type) }
-          @body.lenv.locals[:"*self"] = @body.lenv.cref.get_self(genv)
-
-          @mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@static_cpath)))
-          @changes.add_edge(genv, @mod_val, @mod_cdef.vtx)
-          ret = Vertex.new(self)
-          @changes.add_edge(genv, @body.install(genv), ret)
-          ret
-        else
-          Source.new
-        end
-      end
-
-      def modified_vars(tbl, vars)
-        # skip
+    class SingletonClassNode < ModuleBaseNode
+      def initialize(raw_node, lenv, use_result)
+        super(raw_node, lenv, raw_node.expression, true, raw_node.body, use_result)
       end
     end
   end

--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -14,8 +14,8 @@ module TypeProf::Core
         @cpath = AST.resolve_rbs_name(raw_decl.name, lenv)
         # TODO: decl.type_params
         # TODO: decl.super_class.args
-        ncref = CRef.new(@cpath, true, nil, lenv.cref)
-        nlenv = LocalEnv.new(@lenv.path, ncref, {}, [], nil)
+        ncref = CRef.new(@cpath, :class, nil, lenv.cref)
+        nlenv = LocalEnv.new(@lenv.path, ncref, {}, [])
         @members = raw_decl.members.map do |member|
           AST.create_rbs_member(member, nlenv)
         end.compact

--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -15,7 +15,7 @@ module TypeProf::Core
         # TODO: decl.type_params
         # TODO: decl.super_class.args
         ncref = CRef.new(@cpath, true, nil, lenv.cref)
-        nlenv = LocalEnv.new(@lenv.path, ncref, {}, [])
+        nlenv = LocalEnv.new(@lenv.path, ncref, {}, [], nil)
         @members = raw_decl.members.map do |member|
           AST.create_rbs_member(member, nlenv)
         end.compact

--- a/lib/typeprof/core/env.rb
+++ b/lib/typeprof/core/env.rb
@@ -230,7 +230,7 @@ module TypeProf::Core
     end
 
     def load_core_rbs(raw_decls)
-      lenv = LocalEnv.new(nil, CRef::Toplevel, {}, [])
+      lenv = LocalEnv.new(nil, CRef::Toplevel, {}, [], nil)
       decls = raw_decls.map do |raw_decl|
         AST.create_rbs_decl(raw_decl, lenv)
       end.compact
@@ -274,16 +274,17 @@ module TypeProf::Core
   end
 
   class LocalEnv
-    def initialize(path, cref, locals, return_boxes)
+    def initialize(path, cref, locals, return_boxes, implicit_receiver)
       @path = path
       @cref = cref
       @locals = locals
       @return_boxes = return_boxes
       @next_boxes = []
       @filters = {}
+      @implicit_receiver = implicit_receiver
     end
 
-    attr_reader :path, :cref, :locals, :return_boxes, :next_boxes
+    attr_reader :path, :cref, :locals, :return_boxes, :next_boxes, :implicit_receiver
 
     def new_var(name, node)
       @locals[name] = Vertex.new(node)

--- a/lib/typeprof/core/env/module_entity.rb
+++ b/lib/typeprof/core/env/module_entity.rb
@@ -233,6 +233,8 @@ module TypeProf::Core
               const_read = mdef.superclass_cpath.static_ret
               return const_read ? const_read.cpath : []
             end
+          when AST::SingletonClassNode
+            next
           when AST::ModuleNode
             return nil
           else

--- a/lib/typeprof/core/env/static_read.rb
+++ b/lib/typeprof/core/env/static_read.rb
@@ -79,7 +79,7 @@ module TypeProf::Core
 
     def on_cbase_updated(genv)
       if @cbase && @cbase.cpath
-        resolve(genv, CRef.new(@cbase.cpath, false, nil, nil), true)
+        resolve(genv, CRef.new(@cbase.cpath, :class, nil, nil), true)
       else
         resolution_failed(genv)
       end

--- a/scenario/class/dynamic.rb
+++ b/scenario/class/dynamic.rb
@@ -8,3 +8,13 @@ end
 ## diagnostics
 (1,0)-(2,3): TypeProf cannot analyze a non-static module
 (4,0)-(5,3): TypeProf cannot analyze a non-static class
+
+## update
+Class.new do
+  class << self
+    def foo = :ok
+  end
+end
+
+## diagnostics
+(2,2)-(4,5): TypeProf cannot analyze a non-static class

--- a/scenario/class/self-in-cbase.rb
+++ b/scenario/class/self-in-cbase.rb
@@ -1,0 +1,20 @@
+## update
+class Foo
+  class self::Bar::Baz
+  end
+end
+
+## assert
+class Foo
+  class Foo::Bar::Baz
+  end
+end
+
+## update
+class self::X
+end
+
+## assert
+
+## diagnostics
+(1,0)-(2,3): TypeProf cannot analyze a non-static class

--- a/scenario/class/singleton_class.rb
+++ b/scenario/class/singleton_class.rb
@@ -1,0 +1,37 @@
+## update
+class << Time
+  def foo = :ok
+end
+
+## assert
+class Time
+  def self.foo: -> :ok
+end
+
+## update
+class Foo
+  class << self
+    def foo = :ok
+  end
+end
+
+## assert
+class Foo
+  def self.foo: -> :ok
+end
+
+## update
+class Bar; end
+
+class Foo < Bar
+  class << self
+    def foo = :ok
+  end
+end
+
+## assert
+class Bar
+end
+class Foo < Bar
+  def self.foo: -> :ok
+end

--- a/scenario/known-issues/singleton-class.rb
+++ b/scenario/known-issues/singleton-class.rb
@@ -1,11 +1,21 @@
 ## update
+k = Time
+class << k
+  def foo = :ok
+end
+
+## assert
+class Time
+  def self.foo: -> :ok
+end
+
+## update
 class Foo
   class << self
-    def foo = :ok
+    def self.bar = :ok
   end
 end
 
 ## assert
 class Foo
-  def self.foo: -> :ok
 end


### PR DESCRIPTION
Add support for the following code.

```ruby
class Foo
  class << self
    def foo
      puts 'foo'
    end
  end
end
```

## Additional information

- Added `LocalEnv#implicit_receiver`.
  - This is used when the receiver of `def` is implicitly `self` in a syntax like `class << self`.
  - I feel this is not a good implementation, but I could not find a best implementation. Please review it.
    - Better to allow `CRef` to represent singleton_class...? hmmm... I can't find a best solution 😭 
- I've changed a `Core::Service#dump_declarations` to keep nested class/module nodes in the stack.
  - This allows `Node#traverse` to control the output of `SingletonClassNode` without duplicating the class definition if it already outputs `ClassNode/ModuleNode`.
- Added known-issues for syntax that could not be handled.

