### PR TITLE
Fix the handling of multibyte characters

### DIFF
--- a/lib/typeprof/code_range.rb
+++ b/lib/typeprof/code_range.rb
@@ -55,11 +55,11 @@ module TypeProf
       raise unless first
     end
 
-    def self.from_node(node)
+    def self.from_node(node, encoding = Encoding::UTF_16LE)
       node = node.location if node.is_a?(Prism::Node)
       if node.is_a?(Prism::Location)
-        pos1 = CodePosition.new(node.start_line, node.start_column)
-        pos2 = CodePosition.new(node.end_line, node.end_column)
+        pos1 = CodePosition.new(node.start_line, node.start_code_units_column(encoding))
+        pos2 = CodePosition.new(node.end_line, node.end_code_units_column(encoding))
       elsif node.respond_to?(:location)
         loc = node.location
         row, col = loc.start_loc

--- a/scenario/difinitions/definition.rb
+++ b/scenario/difinitions/definition.rb
@@ -1,0 +1,20 @@
+## update: test.rb
+module Animal
+  class Cat
+    def call
+      puts "meow"
+    end
+  end
+end
+
+Animal::Cat.new.call
+
+## definition: test.rb:9:1
+test.rb:(1,7)-(1,13)
+test.rb:(2,8)-(2,11)
+
+## definition: test.rb:9:9
+test.rb:(2,8)-(2,11)
+
+## definition: test.rb:9:17
+test.rb:(3,8)-(3,12)

--- a/scenario/difinitions/definition_multibyte_characters.rb
+++ b/scenario/difinitions/definition_multibyte_characters.rb
@@ -1,20 +1,19 @@
 ## update: test.rb
 module A動物
   class B猫
-    def call
+    def 🐱🐱🐱
       puts "にゃー"
     end
   end
 end
 
-A動物::B猫
-A動物::B猫.new.call
+A動物::B猫.new.🐱🐱🐱
 
 ## definition: test.rb:9:1
 test.rb:(1,7)-(1,10) # Jump to module
 
-## definition: test.rb:10:6
+## definition: test.rb:9:6
 test.rb:(2,8)-(2,10) # Jump to class
 
-## definition: test.rb:10:13
-test.rb:(3,8)-(3,12) # Jump to #call method
+## definition: test.rb:9:13
+test.rb:(3,8)-(3,14) # Jump to #call method

--- a/scenario/difinitions/definition_multibyte_characters.rb
+++ b/scenario/difinitions/definition_multibyte_characters.rb
@@ -10,10 +10,11 @@ end
 A動物::B猫.new.🐱🐱🐱
 
 ## definition: test.rb:9:1
-test.rb:(1,7)-(1,10) # Jump to module
+test.rb:(1,7)-(1,10)
+test.rb:(2,8)-(2,10)
 
 ## definition: test.rb:9:6
-test.rb:(2,8)-(2,10) # Jump to class
+test.rb:(2,8)-(2,10)
 
 ## definition: test.rb:9:13
-test.rb:(3,8)-(3,14) # Jump to #call method
+test.rb:(3,8)-(3,14)


### PR DESCRIPTION
When a Ruby file contains multibyte characters such as Japanese, Chinese, or emojis, features like "go to definition" or "hover" don't work correctly. Because multibyte characters are not considered in position calculations.

Prism provides a code unit API to address these issues. My understanding, while the position calculation cost increases when multibyte characters are present, there is little to no change in cost otherwise.
https://docs.ruby-lang.org/en/master/Prism/Location.html#method-i-start_code_units_column

In this pull request, I fix the code to use the code unit API to correctly calculate positions with multibyte characters.

|Before|After|
|------|-----|
|![image](https://github.com/ruby/typeprof/assets/8983747/b2d75d1e-13c0-4ce9-837c-3df194a1fb6c)|![image](https://github.com/ruby/typeprof/assets/8983747/2691067e-4d49-49e2-a5c5-34a403a42f2f)|

ref: https://github.com/ruby/typeprof/pull/183
