### PR TITLE
Vertex#show_name is no longer useful for debugging

### DIFF
--- a/lib/typeprof/core/ast/base.rb
+++ b/lib/typeprof/core/ast/base.rb
@@ -238,7 +238,7 @@ module TypeProf::Core
       end
 
       def install0(_)
-        Vertex.new("dummy_rhs", self)
+        Vertex.new(self)
       end
     end
 

--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -101,12 +101,12 @@ module TypeProf::Core
           vars.uniq!
           vars.each do |var|
             vtx = @lenv.get_var(var)
-            nvtx = vtx.new_vertex(genv, "#{ vtx.show_name }'", self)
+            nvtx = vtx.new_vertex(genv, self)
             @lenv.set_var(var, nvtx)
             @block_body.lenv.set_var(var, nvtx)
           end
 
-          e_ret = @block_body.lenv.locals[:"*expected_block_ret"] = Vertex.new("expected_method_ret", self)
+          e_ret = @block_body.lenv.locals[:"*expected_block_ret"] = Vertex.new(self)
           @block_body.install(genv)
           @block_body.lenv.add_next_box(@changes.add_escape_box(genv, @block_body.ret, e_ret))
 

--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -26,7 +26,7 @@ module TypeProf::Core
       def subnodes = { cond:, then:, else: }
 
       def install0(genv)
-        ret = Vertex.new("if", self)
+        ret = Vertex.new(self)
 
         @cond.install(genv)
 
@@ -39,8 +39,8 @@ module TypeProf::Core
         modified_vtxs = {}
         vars.uniq.each do |var|
           vtx = @lenv.get_var(var)
-          nvtx_then = vtx.new_vertex(genv, "#{ vtx.is_a?(Vertex) ? vtx.show_name : "???" }'", self)
-          nvtx_else = vtx.new_vertex(genv, "#{ vtx.is_a?(Vertex) ? vtx.show_name : "???" }'", self)
+          nvtx_then = vtx.new_vertex(genv, self)
+          nvtx_else = vtx.new_vertex(genv, self)
           modified_vtxs[var] = [nvtx_then, nvtx_else]
         end
         if @cond.is_a?(LocalVariableReadNode)
@@ -91,7 +91,7 @@ module TypeProf::Core
         modified_vtxs.each do |var, (nvtx_then, nvtx_else)|
           nvtx_then = BotFilter.new(genv, self, nvtx_then, then_val).next_vtx
           nvtx_else = BotFilter.new(genv, self, nvtx_else, else_val).next_vtx
-          nvtx_join = nvtx_then.new_vertex(genv, "xxx", self)
+          nvtx_join = nvtx_then.new_vertex(genv, self)
           @changes.add_edge(genv, nvtx_else, nvtx_join)
           @lenv.set_var(var, nvtx_join)
         end
@@ -126,7 +126,7 @@ module TypeProf::Core
         old_vtxs = {}
         vars.each do |var|
           vtx = @lenv.get_var(var)
-          nvtx = vtx.new_vertex(genv, "#{ vtx.is_a?(Vertex) ? vtx.show_name : "???" }'", self)
+          nvtx = vtx.new_vertex(genv, self)
           old_vtxs[var] = nvtx
           @lenv.set_var(var, nvtx)
         end
@@ -240,7 +240,7 @@ module TypeProf::Core
       def subnodes = { pivot:, whens:, clauses:, else_clause: }
 
       def install0(genv)
-        ret = Vertex.new("case", self)
+        ret = Vertex.new(self)
         @pivot&.install(genv)
         @whens.zip(@clauses) do |vals, clause|
           vals.install(genv)
@@ -263,7 +263,7 @@ module TypeProf::Core
       def subnodes = { e1:, e2: }
 
       def install0(genv)
-        ret = Vertex.new("and", self)
+        ret = Vertex.new(self)
         @changes.add_edge(genv, @e1.install(genv), ret)
         @changes.add_edge(genv, @e2.install(genv), ret)
         ret
@@ -282,7 +282,7 @@ module TypeProf::Core
       def subnodes = { e1:, e2: }
 
       def install0(genv)
-        ret = Vertex.new("or", self)
+        ret = Vertex.new(self)
         v1 = @e1.install(genv)
         v1 = NilFilter.new(genv, self, v1, false).next_vtx
         @changes.add_edge(genv, v1, ret)
@@ -358,7 +358,7 @@ module TypeProf::Core
       end
 
       def install0(genv)
-        ret = Vertex.new("rescue-ret", self)
+        ret = Vertex.new(self)
         @changes.add_edge(genv, @body.install(genv), ret)
         @rescue_conds.each {|cond| cond.install(genv) }
         @rescue_clauses.each {|clause| @changes.add_edge(genv, clause.install(genv), ret) }

--- a/lib/typeprof/core/ast/meta.rb
+++ b/lib/typeprof/core/ast/meta.rb
@@ -133,7 +133,7 @@ module TypeProf::Core
           box = @changes.add_ivar_read_box(genv, @lenv.cref.cpath, false, :"@#{ arg }")
           @changes.add_method_def_box(genv, @lenv.cref.cpath, false, arg, FormalArguments::Empty, [box])
 
-          vtx = Vertex.new("attr_writer-arg", self)
+          vtx = Vertex.new(self)
           @changes.add_edge(genv, vtx, ive.vtx)
           f_args = FormalArguments.new([vtx], [], nil, [], [], [], nil, nil)
           @changes.add_method_def_box(genv, @lenv.cref.cpath, false, :"#{ arg }=", f_args, [box])

--- a/lib/typeprof/core/ast/method.rb
+++ b/lib/typeprof/core/ast/method.rb
@@ -220,7 +220,7 @@ module TypeProf::Core
         end
 
         if @body
-          e_ret = @body.lenv.locals[:"*expected_method_ret"] = Vertex.new("expected_method_ret", self)
+          e_ret = @body.lenv.locals[:"*expected_method_ret"] = Vertex.new(self)
           @body.install(genv)
           @body.lenv.add_return_box(@changes.add_escape_box(genv, @body.ret, e_ret))
         end

--- a/lib/typeprof/core/ast/misc.rb
+++ b/lib/typeprof/core/ast/misc.rb
@@ -23,7 +23,7 @@ module TypeProf::Core
           ret = stmt ? stmt.install(genv) : nil
         end
         if ret
-          ret2 = Vertex.new("stmts_result", self)
+          ret2 = Vertex.new(self)
           @changes.add_edge(genv, ret, ret2)
           ret2
         else

--- a/lib/typeprof/core/ast/module.rb
+++ b/lib/typeprof/core/ast/module.rb
@@ -63,7 +63,7 @@ module TypeProf::Core
 
           @mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@static_cpath)))
           @changes.add_edge(genv, @mod_val, @mod_cdef.vtx)
-          ret = Vertex.new("module_return", self)
+          ret = Vertex.new(self)
           @changes.add_edge(genv, @body.install(genv), ret)
           ret
         else

--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -75,7 +75,7 @@ module TypeProf::Core
       end
 
       def contravariant_vertex(genv, changes, subst)
-        vtx = Vertex.new("rbs_type", self)
+        vtx = Vertex.new(self)
         contravariant_vertex0(genv, changes, vtx, subst)
         vtx
       end
@@ -447,7 +447,7 @@ module TypeProf::Core
       def subnodes = { types: }
 
       def covariant_vertex0(genv, changes, vtx, subst)
-        unified_elem = Vertex.new("ary-unified", self) # TODO
+        unified_elem = Vertex.new(self) # TODO
         elems = @types.map do |type|
           nvtx = type.covariant_vertex(genv, changes, subst)
           nvtx.add_edge(genv, unified_elem)
@@ -457,7 +457,7 @@ module TypeProf::Core
       end
 
       def contravariant_vertex0(genv, changes, vtx, subst)
-        unified_elem = Vertex.new("ary-unified", self)
+        unified_elem = Vertex.new(self)
         elems = @types.map do |type|
           nvtx = type.contravariant_vertex(genv, changes, subst)
           nvtx.add_edge(genv, unified_elem)

--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -224,7 +224,7 @@ module TypeProf::Core
       def subnodes = { begin:, end: }
 
       def install0(genv)
-        elem = Vertex.new("range-elem", self)
+        elem = Vertex.new(self)
         @changes.add_edge(genv, @begin.install(genv), elem)
         @changes.add_edge(genv, @end.install(genv), elem)
         Source.new(genv.gen_range_type(elem))
@@ -242,8 +242,8 @@ module TypeProf::Core
       def subnodes = { elems: }
 
       def install0(genv)
-        elems = @elems.map {|e| e.install(genv).new_vertex(genv, "ary-elem", self) }
-        unified_elem = Vertex.new("ary-elems-unified", self)
+        elems = @elems.map {|e| e.install(genv).new_vertex(genv, self) }
+        unified_elem = Vertex.new(self)
         elems.each {|vtx| @changes.add_edge(genv, vtx, unified_elem) }
         Source.new(Type::Array.new(genv, elems, genv.gen_ary_type(unified_elem)))
       end
@@ -274,13 +274,13 @@ module TypeProf::Core
       def attrs = { keywords: }
 
       def install0(genv)
-        unified_key = Vertex.new("hash-keys-unified", self)
-        unified_val = Vertex.new("hash-vals-unified", self)
+        unified_key = Vertex.new(self)
+        unified_val = Vertex.new(self)
         literal_pairs = {}
         @keys.zip(@vals) do |key, val|
           if key
-            k = key.install(genv).new_vertex(genv, "hash-key", self)
-            v = val.install(genv).new_vertex(genv, "hash-val", self)
+            k = key.install(genv).new_vertex(genv, self)
+            v = val.install(genv).new_vertex(genv, self)
             @changes.add_edge(genv, k, unified_key)
             @changes.add_edge(genv, v, unified_val)
             literal_pairs[key.lit] = v if key.is_a?(SymbolNode)

--- a/lib/typeprof/core/ast/variable.rb
+++ b/lib/typeprof/core/ast/variable.rb
@@ -106,7 +106,7 @@ module TypeProf::Core
       def install0(genv)
         @changes.add_ivar_read_box(genv, @lenv.cref.cpath, @lenv.cref.singleton, @var)
         val = @rhs.install(genv)
-        val = val.new_vertex(genv, "iasgn", self) # avoid multi-edge from val to static_ret.vtx
+        val = val.new_vertex(genv, self) # avoid multi-edge from val to static_ret.vtx
         @changes.add_edge(genv, val, @static_ret.vtx)
         val
       end
@@ -217,7 +217,7 @@ module TypeProf::Core
       def install0(genv)
         @changes.add_cvar_read_box(genv, @lenv.cref.cpath, @var)
         val = @rhs.install(genv)
-        val = val.new_vertex(genv, "casgn", self) # avoid multi-edge from val to static_ret.vtx
+        val = val.new_vertex(genv, self) # avoid multi-edge from val to static_ret.vtx
         @changes.add_edge(genv, val, @static_ret.vtx)
         val
       end

--- a/lib/typeprof/core/env.rb
+++ b/lib/typeprof/core/env.rb
@@ -286,7 +286,7 @@ module TypeProf::Core
     attr_reader :path, :cref, :locals, :return_boxes, :next_boxes
 
     def new_var(name, node)
-      @locals[name] = Vertex.new("var:#{ name }", node)
+      @locals[name] = Vertex.new(node)
     end
 
     def set_var(name, vtx)

--- a/lib/typeprof/core/env/method.rb
+++ b/lib/typeprof/core/env/method.rb
@@ -33,11 +33,11 @@ module TypeProf::Core
 
     attr_reader :positionals, :splat_flags, :keywords, :block
 
-    def new_vertexes(genv, name, node)
-      positionals = @positionals.map {|arg| arg.new_vertex(genv, "arg:#{ name }", node) }
+    def new_vertexes(genv, node)
+      positionals = @positionals.map {|arg| arg.new_vertex(genv, node) }
       splat_flags = @splat_flags
-      keywords = @keywords ? @keywords.new_vertex(genv, "kw:#{ name }", node) : nil
-      block = @block ? @block.new_vertex(genv, "block:#{ name }", node) : nil
+      keywords = @keywords ? @keywords.new_vertex(genv, node) : nil
+      block = @block ? @block.new_vertex(genv, node) : nil
       ActualArguments.new(positionals, splat_flags, keywords, block)
     end
 
@@ -98,11 +98,11 @@ module TypeProf::Core
       @node = node
       @used = false
       @f_args = []
-      @ret = Vertex.new("record_block_ret", node)
+      @ret = Vertex.new(node)
     end
 
     def get_f_arg(i)
-      @f_args[i] ||= Vertex.new("record_block_arg", @node)
+      @f_args[i] ||= Vertex.new(@node)
     end
 
     attr_reader :node, :f_args, :ret, :used

--- a/lib/typeprof/core/env/value_entity.rb
+++ b/lib/typeprof/core/env/value_entity.rb
@@ -4,7 +4,7 @@ module TypeProf::Core
       @decls = Set[]
       @defs = Set[]
       @read_boxes = Set[]
-      @vtx = Vertex.new("gvar", self)
+      @vtx = Vertex.new(self)
     end
 
     attr_reader :decls, :defs, :read_boxes, :vtx

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -61,7 +61,7 @@ module TypeProf::Core
       super(node)
       @const_read = const_read
       const_read.followers << self
-      @ret = Vertex.new("cname", node)
+      @ret = Vertex.new(node)
       genv.add_run(self)
     end
 
@@ -80,7 +80,7 @@ module TypeProf::Core
     def initialize(node, genv, rbs_type)
       super(node)
       @rbs_type = rbs_type
-      @ret = Vertex.new("type-read", node)
+      @ret = Vertex.new(node)
       genv.add_run(self)
     end
 
@@ -185,7 +185,7 @@ module TypeProf::Core
         param_map0 = param_map.dup
         if method_type.type_params
           method_type.type_params.map do |var|
-            vtx = Vertex.new("ty-var-#{ var }", node)
+            vtx = Vertex.new(node)
             param_map0[var] = vtx
           end
         end
@@ -299,7 +299,7 @@ module TypeProf::Core
       end
 
       @ret_boxes = ret_boxes
-      @ret = Vertex.new("ret:#{ mid }", node)
+      @ret = Vertex.new(node)
       ret_boxes.each do |box|
         @changes.add_edge(genv, box.ret, @ret)
       end
@@ -575,14 +575,14 @@ module TypeProf::Core
     def initialize(node, genv, recv, mid, a_args, subclasses)
       raise mid.to_s unless mid
       super(node)
-      @recv = recv.new_vertex(genv, "recv:#{ mid }", node)
+      @recv = recv.new_vertex(genv, node)
       @recv.add_edge(genv, self)
       @mid = mid
-      @a_args = a_args.new_vertexes(genv, mid, node)
+      @a_args = a_args.new_vertexes(genv, node)
       @a_args.positionals.each {|arg| arg.add_edge(genv, self) }
       @a_args.keywords.add_edge(genv, self) if @a_args.keywords
       @a_args.block.add_edge(genv, self) if @a_args.block
-      @ret = Vertex.new("ret:#{ mid }", node)
+      @ret = Vertex.new(node)
       @subclasses = subclasses
     end
 
@@ -763,7 +763,7 @@ module TypeProf::Core
     def initialize(node, genv, name)
       super(node)
       @vtx = genv.resolve_gvar(name).vtx
-      @ret = Vertex.new("gvar", node)
+      @ret = Vertex.new(node)
       genv.add_run(self)
     end
 
@@ -781,8 +781,8 @@ module TypeProf::Core
       @singleton = singleton
       @name = name
       genv.resolve_cpath(cpath).ivar_reads << self
-      @proxy = Vertex.new("ivar", node)
-      @ret = Vertex.new("ivar", node)
+      @proxy = Vertex.new(node)
+      @ret = Vertex.new(node)
       genv.add_run(self)
     end
 
@@ -825,8 +825,8 @@ module TypeProf::Core
       @cpath = cpath
       @name = name
       genv.resolve_cpath(cpath).cvar_reads << self
-      @proxy = Vertex.new("cvar", node)
-      @ret = Vertex.new("cvar", node)
+      @proxy = Vertex.new(node)
+      @ret = Vertex.new(node)
       genv.add_run(self)
     end
 

--- a/lib/typeprof/core/graph/change_set.rb
+++ b/lib/typeprof/core/graph/change_set.rb
@@ -46,7 +46,7 @@ module TypeProf::Core
 
     def new_vertex(genv, sig_type_node)
       # This is used to avoid duplicated vertex generation for the same sig node
-      @covariant_types[sig_type_node] ||= Vertex.new("rbs_type", sig_type_node)
+      @covariant_types[sig_type_node] ||= Vertex.new(sig_type_node)
     end
 
     def add_edge(genv, src, dst)

--- a/lib/typeprof/core/graph/filter.rb
+++ b/lib/typeprof/core/graph/filter.rb
@@ -8,7 +8,7 @@ module TypeProf::Core
   class NilFilter < Filter
     def initialize(genv, node, prev_vtx, allow_nil)
       @node = node
-      @next_vtx = Vertex.new("#{ prev_vtx.show_name }:filter", node)
+      @next_vtx = Vertex.new(node)
       @allow_nil = allow_nil
       prev_vtx.add_edge(genv, self)
     end
@@ -42,7 +42,7 @@ module TypeProf::Core
       @types = Set[]
       @const_read = const_read
       @const_read.followers << self
-      @next_vtx = Vertex.new("#{ prev_vtx.show_name }:filter", node)
+      @next_vtx = Vertex.new(node)
       prev_vtx.add_edge(genv, self)
       @neg = neg
     end
@@ -98,7 +98,7 @@ module TypeProf::Core
       @node = node
       @types = {}
       @prev_vtx = prev_vtx
-      @next_vtx = Vertex.new("#{ prev_vtx.show_name }:botfilter", node)
+      @next_vtx = Vertex.new(node)
       @base_vtx = base_vtx
       base_vtx.add_edge(genv, self)
       prev_vtx.add_edge(genv, self) if prev_vtx != base_vtx

--- a/lib/typeprof/core/graph/filter.rb
+++ b/lib/typeprof/core/graph/filter.rb
@@ -13,7 +13,7 @@ module TypeProf::Core
       prev_vtx.add_edge(genv, self)
     end
 
-    attr_reader :show_name, :next_vtx, :allow_nil
+    attr_reader :next_vtx, :allow_nil
 
     def filter(types, nil_type)
       types.select {|ty| (ty == nil_type) == @allow_nil }

--- a/lib/typeprof/core/graph/vertex.rb
+++ b/lib/typeprof/core/graph/vertex.rb
@@ -99,8 +99,8 @@ module TypeProf::Core
     def on_type_removed(genv, src_var, removed_types)
     end
 
-    def new_vertex(genv, show_name, origin)
-      nvtx = Vertex.new(show_name, origin)
+    def new_vertex(genv, origin)
+      nvtx = Vertex.new(origin)
       add_edge(genv, nvtx)
       nvtx
     end
@@ -134,10 +134,9 @@ module TypeProf::Core
   end
 
   class Vertex < BasicVertex
-    def initialize(show_name, origin)
-      # Note that show_name and origin are just for debug.
+    def initialize(origin)
+      # Note that origin is just for debug.
       # When an AST node is reused, the value of the origin will be invalid.
-      @show_name = show_name
       case origin
       when AST::Node
       when RBS::AST::Declarations::Base
@@ -149,7 +148,7 @@ module TypeProf::Core
       super({})
     end
 
-    attr_reader :show_name, :next_vtxs, :types
+    attr_reader :next_vtxs, :types
 
     def on_type_added(genv, src_var, added_types)
       new_added_types = []
@@ -191,8 +190,8 @@ module TypeProf::Core
       end
     end
 
-    def new_vertex(genv, show_name, origin)
-      nvtx = Vertex.new(show_name, origin)
+    def new_vertex(genv, origin)
+      nvtx = Vertex.new(origin)
       add_edge(genv, nvtx)
       nvtx
     end
@@ -210,7 +209,7 @@ module TypeProf::Core
     $new_id = 0 # TODO: Use class variable
 
     def to_s
-      "v#{ @id ||= $new_id += 1 }:#{ @show_name }"
+      "v#{ @id ||= $new_id += 1 }"
     end
 
     alias inspect to_s


### PR DESCRIPTION
Removed `Vertex#show_name` because it is no longer useful for debugging.
related: #221 (comment)

I agree with removing it, as I never use it and had more trouble naming `show_name`.