### PR TITLE
Fixed an error that occurred with a call with no method name.

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -163,7 +163,7 @@ module TypeProf::Core
       def initialize(raw_node, lenv)
         recv = raw_node.receiver ? AST.create_node(raw_node.receiver, lenv) : nil
         mid = raw_node.name
-        mid_code_range = TypeProf::CodeRange.from_node(raw_node.message_loc)
+        mid_code_range = TypeProf::CodeRange.from_node(raw_node.message_loc) if raw_node.message_loc
         raw_args = raw_node.arguments
         raw_block = raw_node.block
         super(raw_node, recv, mid, mid_code_range, raw_args, nil, raw_block, lenv)

--- a/scenario/lambda/basic1.rb
+++ b/scenario/lambda/basic1.rb
@@ -7,3 +7,14 @@ end
 class Object
   def foo: -> Proc
 end
+
+## update
+def foo
+  b = -> () { 1 }
+  b.()
+end
+
+## assert
+class Object
+  def foo: -> untyped
+end


### PR DESCRIPTION
Fixed an error that occurred in the following code.

```ruby
b = -> {}

 # https://github.com/ruby/typeprof//blob/049c296260fa9de3e0298757547c12afd805a693/lib/typeprof/code_range.rb#L71-L71
b.() #=> unknown type: NilClass
```