### PR TITLE
Prevent node reusing when the method definition result is used

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -18,8 +18,8 @@ module TypeProf::Core
       ProgramNode.new(raw_scope, lenv)
     end
 
-    #: (untyped, TypeProf::Core::LocalEnv) -> TypeProf::Core::AST::Node
-    def self.create_node(raw_node, lenv)
+    #: (untyped, TypeProf::Core::LocalEnv, ?bool) -> TypeProf::Core::AST::Node
+    def self.create_node(raw_node, lenv, use_result = true)
       while true
         case raw_node.type
         when :parentheses_node
@@ -34,10 +34,10 @@ module TypeProf::Core
       case raw_node.type
 
       # definition
-      when :statements_node then StatementsNode.new(raw_node, lenv)
-      when :module_node then ModuleNode.new(raw_node, lenv)
-      when :class_node then ClassNode.new(raw_node, lenv)
-      when :def_node then DefNode.new(raw_node, lenv)
+      when :statements_node then StatementsNode.new(raw_node, lenv, use_result)
+      when :module_node then ModuleNode.new(raw_node, lenv, use_result)
+      when :class_node then ClassNode.new(raw_node, lenv, use_result)
+      when :def_node then DefNode.new(raw_node, lenv, use_result)
       when :alias_method_node then AliasNode.new(raw_node, lenv)
 
       # control

--- a/lib/typeprof/core/ast/base.rb
+++ b/lib/typeprof/core/ast/base.rb
@@ -20,6 +20,7 @@ module TypeProf::Core
       def subnodes = {}
       def attrs = {}
 
+      #: { (TypeProf::Core::AST::Node) -> void } -> nil
       def each_subnode
         queue = subnodes.values
 
@@ -196,7 +197,7 @@ module TypeProf::Core
         @tbl = raw_node.locals
         raw_body = raw_node.statements
 
-        @body = AST.create_node(raw_body, lenv)
+        @body = AST.create_node(raw_body, lenv, false)
       end
 
       attr_reader :tbl, :body

--- a/lib/typeprof/core/ast/misc.rb
+++ b/lib/typeprof/core/ast/misc.rb
@@ -1,11 +1,12 @@
 module TypeProf::Core
   class AST
     class StatementsNode < Node
-      def initialize(raw_node, lenv)
+      def initialize(raw_node, lenv, use_result)
         super(raw_node, lenv)
-        @stmts = raw_node.body.map do |n|
+        stmts = raw_node.body
+        @stmts = stmts.map.with_index do |n, i|
           if n
-            AST.create_node(n, lenv)
+            AST.create_node(n, lenv, i == stmts.length - 1 ? use_result : false)
           else
             last = code_range.last
             DummyNilNode.new(TypeProf::CodeRange.new(last, last), lenv)

--- a/lib/typeprof/core/ast/module.rb
+++ b/lib/typeprof/core/ast/module.rb
@@ -1,7 +1,7 @@
 module TypeProf::Core
   class AST
     class ModuleBaseNode < Node
-      def initialize(raw_node, lenv, raw_cpath, raw_scope)
+      def initialize(raw_node, lenv, raw_cpath, raw_scope, use_result)
         super(raw_node, lenv)
 
         @cpath = AST.create_node(raw_cpath, lenv)
@@ -13,7 +13,7 @@ module TypeProf::Core
         if @static_cpath
           ncref = CRef.new(@static_cpath, true, nil, lenv.cref)
           nlenv = LocalEnv.new(@lenv.path, ncref, {}, [])
-          @body = raw_scope ? AST.create_node(raw_scope, nlenv) : DummyNilNode.new(code_range, lenv)
+          @body = raw_scope ? AST.create_node(raw_scope, nlenv, use_result) : DummyNilNode.new(code_range, lenv)
         else
           @body = nil
         end
@@ -77,14 +77,14 @@ module TypeProf::Core
     end
 
     class ModuleNode < ModuleBaseNode
-      def initialize(raw_node, lenv)
-        super(raw_node, lenv, raw_node.constant_path, raw_node.body)
+      def initialize(raw_node, lenv, use_result)
+        super(raw_node, lenv, raw_node.constant_path, raw_node.body, use_result)
       end
     end
 
     class ClassNode < ModuleBaseNode
-      def initialize(raw_node, lenv)
-        super(raw_node, lenv, raw_node.constant_path, raw_node.body)
+      def initialize(raw_node, lenv, use_result)
+        super(raw_node, lenv, raw_node.constant_path, raw_node.body, use_result)
         raw_superclass = raw_node.superclass
         @superclass_cpath = raw_superclass ? AST.create_node(raw_superclass, lenv) : nil
       end

--- a/scenario/method/prevent-reuse.rb
+++ b/scenario/method/prevent-reuse.rb
@@ -1,0 +1,13 @@
+## update: test.rb
+class Foo
+  ary =
+  def foo
+  end
+end
+
+## update: test.rb
+class Foo
+  ary =
+  def foo
+  end
+end


### PR DESCRIPTION
Typically, `v = def foo; end` made the invariant check fail due to node reusing. This pattern should be very rare, so I handle this issue by preventing node reusing if the result of the method definition is used.

Note that `private def ...` will prevent node reusing. I think this pattern should be handled separatedly when we support method visibility.