### PR TITLE
Add an RBS for "TypeProf" namespace

### DIFF
--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -293,13 +293,13 @@ module TypeProf::Core
       end
     end
 
-    class LambdaNode < TypeProf::Core::AST::Node
+    class LambdaNode < Node
       def install0(genv)
         Source.new(genv.proc_type)
       end
     end
 
-    class ImaginaryNode < TypeProf::Core::AST::Node
+    class ImaginaryNode < Node
       def install0(genv)
         Source.new(genv.complex_type)
       end

--- a/scenario/class/unknown-cbase.rb
+++ b/scenario/class/unknown-cbase.rb
@@ -1,0 +1,37 @@
+## update: test.rb
+class Foo::Bar
+  class C
+    def foo
+      1
+    end
+  end
+end
+
+# Currently, Foo::Bar::C cannot be resolved because there is no definition of Foo
+class D < Foo::Bar::C
+  def check = foo
+end
+
+## assert: test.rb
+class Foo::Bar
+  class Foo::Bar::C
+    def foo: -> Integer
+  end
+end
+class D # failed to identify its superclass
+  def check: -> untyped
+end
+
+## update: test.rbs
+module Foo
+end
+
+## assert: test.rb
+class Foo::Bar
+  class Foo::Bar::C
+    def foo: -> Integer
+  end
+end
+class D < Foo::Bar::C
+  def check: -> Integer
+end

--- a/sig/typeprof.rbs
+++ b/sig/typeprof.rbs
@@ -1,0 +1,2 @@
+module TypeProf
+end


### PR DESCRIPTION
`LambdaNode.new` was warned because its superclass `TypeProf::Core::AST::Node` couldn't be resolved. Adding `TypeProf` module as a RBS resolves the issue.