### PR TITLE
Ad-hoc fix for mutually recursive aliases

### DIFF
--- a/lib/typeprof/core/env/method_entity.rb
+++ b/lib/typeprof/core/env/method_entity.rb
@@ -28,8 +28,8 @@ module TypeProf::Core
       @defs.delete(mdef) || raise
     end
 
-    def add_alias(node, old_me)
-      @aliases[node] = old_me || raise
+    def add_alias(node, old_mid)
+      @aliases[node] = old_mid
     end
 
     def remove_alias(node)
@@ -37,7 +37,7 @@ module TypeProf::Core
     end
 
     def exist?
-      @builtin || !@decls.empty? || !@defs.empty? || !@aliases.empty?
+      @builtin || !@decls.empty? || !@defs.empty?
     end
 
     def add_run_all_mdefs(genv)

--- a/scenario/method/self-alias.rb
+++ b/scenario/method/self-alias.rb
@@ -12,3 +12,45 @@ end
 class C
   def foo: -> Integer
 end
+
+## update
+class C
+  def foo
+    foo
+    42
+  end
+  alias foo bar
+  alias bar foo
+end
+
+## assert
+class C
+  def foo: -> Integer
+end
+
+## update
+class C
+  def bar
+    foo
+    42
+  end
+  alias foo bar
+  alias bar foo
+end
+
+## assert
+class C
+  def bar: -> Integer
+end
+
+## update
+class C
+  alias foo bar
+  alias bar foo
+end
+
+C.new.foo
+
+## assert
+class C
+end

--- a/scenario/misc/super-with-alias.rb
+++ b/scenario/misc/super-with-alias.rb
@@ -1,0 +1,26 @@
+## update
+class C
+  def foo
+    42
+  end
+end
+
+class D < C
+  alias bar foo
+end
+
+class E < D
+  def bar
+    super
+  end
+end
+
+## assert
+class C
+  def foo: -> Integer
+end
+class D < C
+end
+class E < D
+  def bar: -> Integer
+end


### PR DESCRIPTION
It should be handled more elegantly by detecting recursive alias when defined.