### PR TITLE
Fix `TypeError: wrong argument type NilClass (must respond to :each)`

### DIFF
--- a/lib/typeprof/core/env.rb
+++ b/lib/typeprof/core/env.rb
@@ -125,7 +125,7 @@ module TypeProf::Core
       if singleton
         Type::Singleton.new(self, super_mod)
       else
-        get_instance_type(super_mod, ty.mod.superclass_type_args, changes, base_ty_env, ty)
+        get_instance_type(super_mod, ty.mod.superclass_type_args || [], changes, base_ty_env, ty)
       end
     end
 

--- a/scenario/misc/super.rb
+++ b/scenario/misc/super.rb
@@ -24,3 +24,15 @@ end
 class D2 < C
   def foo: -> :str
 end
+
+## update
+class StringifyKeyHash < Hash
+  def [](key)
+    super(key.to_s)
+  end
+end
+
+## assert
+class StringifyKeyHash < Hash
+  def []: (untyped) -> untyped
+end


### PR DESCRIPTION
This error occurred when I tested `typeprof` on `test-unit`. 
https://github.com/test-unit/test-unit/blob/24fb08fe31835b0d9ade80fb2f51554e55d1a74a/lib/test/unit/attribute.rb#L4

Although `superclass_type_args` may be nil, it was passed to `Array#zip` and raised a TypeError. https://github.com/ruby/typeprof/blob/c440ce91d8903c9e284f911b13ca49320f6a1fb7/lib/typeprof/core/env.rb#L115

I changed it to if superclass_type_args is nil, use an empty array instead.