### PR TITLE
Fix indentation warning

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -200,7 +200,7 @@ module TypeProf::Core
       else
         DummyNilNode.new(code_range, lenv)
       end
-  end
+    end
 
     class NextNode < Node
       def initialize(raw_node, lenv)


### PR DESCRIPTION
```
lib/typeprof/core/ast/control.rb:203: warning: mismatched indentations at 'end' with 'def' at 192
```