### PR TITLE
Fix double-edge error when the same keyword hash is passed to a method

### DIFF
--- a/lib/typeprof/core/env/method.rb
+++ b/lib/typeprof/core/env/method.rb
@@ -62,6 +62,23 @@ module TypeProf::Core
 
       vtxs.uniq
     end
+
+    def get_keyword_arg(genv, changes, name)
+      vtx = Vertex.new(self)
+      @keywords.each_type do |ty|
+        case ty
+        when Type::Hash
+          changes.add_edge(genv, ty.get_value(name), vtx)
+        when Type::Instance
+          if ty.mod == genv.mod_hash
+            changes.add_edge(genv, ty.args[1], vtx)
+          end
+        else
+          # what to do?
+        end
+      end
+      vtx
+    end
   end
 
   class Block

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -530,33 +530,11 @@ module TypeProf::Core
       if a_args.keywords
         # TODO: support diagnostics
         @node.req_keywords.zip(@f_args.req_keywords) do |name, f_vtx|
-          a_args.keywords.each_type do |ty|
-            case ty
-            when Type::Hash
-              changes.add_edge(genv, ty.get_value(name), f_vtx)
-            when Type::Instance
-              if ty.mod == genv.mod_hash
-                changes.add_edge(genv, ty.args[1], f_vtx)
-              end
-            else
-              # what to do?
-            end
-          end
+          changes.add_edge(genv, a_args.get_keyword_arg(genv, changes, name), f_vtx)
         end
 
         @node.opt_keywords.zip(@f_args.opt_keywords).each do |name, f_vtx|
-          a_args.keywords.each_type do |ty|
-            case ty
-            when Type::Hash
-              changes.add_edge(genv, ty.get_value(name), f_vtx)
-            when Type::Instance
-              if ty.mod == genv.mod_hash
-                changes.add_edge(genv, ty.args[1], f_vtx)
-              end
-            else
-              # what to do?
-            end
-          end
+          changes.add_edge(genv, a_args.get_keyword_arg(genv, changes, name), f_vtx)
         end
 
         if @node.rest_keywords

--- a/scenario/args/keyword-twice.rb
+++ b/scenario/args/keyword-twice.rb
@@ -1,0 +1,37 @@
+## update
+class Foo
+  def initialize(k:)
+  end
+end
+
+class Bar < Foo
+end
+
+obj = rand < 0.5 ? Foo : Bar
+obj.new(k: 1)
+
+## assert
+class Foo
+  def initialize: (k: Integer) -> nil
+end
+class Bar < Foo
+end
+
+## update
+class Foo
+  def initialize(k: :default)
+  end
+end
+
+class Bar < Foo
+end
+
+obj = rand < 0.5 ? Foo : Bar
+obj.new(k: 1)
+
+## assert
+class Foo
+  def initialize: (?k: :default | Integer) -> nil
+end
+class Bar < Foo
+end


### PR DESCRIPTION
This pattern was found in optparse