### PR TITLE
Prevent the analysis from getting stuck

### DIFF
--- a/lib/typeprof/core/graph/change_set.rb
+++ b/lib/typeprof/core/graph/change_set.rb
@@ -4,6 +4,7 @@ module TypeProf::Core
       @node = node
       @target = target
       @covariant_types = {}
+      @contravariant_types = {}
       @edges = []
       @new_edges = []
       @boxes = {}
@@ -44,9 +45,14 @@ module TypeProf::Core
       other.diagnostics.clear
     end
 
-    def new_vertex(genv, sig_type_node)
+    def new_covariant_vertex(genv, sig_type_node)
       # This is used to avoid duplicated vertex generation for the same sig node
       @covariant_types[sig_type_node] ||= Vertex.new(sig_type_node)
+    end
+
+    def new_contravariant_vertex(genv, sig_type_node)
+      # This is used to avoid duplicated vertex generation for the same sig node
+      @contravariant_types[sig_type_node] ||= Vertex.new(sig_type_node)
     end
 
     def add_edge(genv, src, dst)

--- a/lib/typeprof/core/graph/vertex.rb
+++ b/lib/typeprof/core/graph/vertex.rb
@@ -142,6 +142,7 @@ module TypeProf::Core
       when RBS::AST::Declarations::Base
       when ValueEntity
       when ActualArguments
+      when Array
       else
         raise "unknown class: #{ origin.class }"
       end

--- a/scenario/misc/ivar-stuck-case.rb
+++ b/scenario/misc/ivar-stuck-case.rb
@@ -1,0 +1,12 @@
+## update: test.rbs
+class Foo
+  def check: [T] (T) -> [T]
+end
+
+## update: test.rb
+class Foo
+  def foo
+    @foo = []
+    @foo = check(@foo)
+  end
+end


### PR DESCRIPTION
Creating a new vertex in argument matching may cause infinite loop. See scenario/misc/ivar-stuck-case.rb.