### PR TITLE
Temporarily ignore "return" in non-method scope

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -313,8 +313,8 @@ module TypeProf::Core
 
       def install0(genv)
         @arg.install(genv)
-        e_ret = @lenv.get_var(:"*expected_method_ret")
-        @lenv.add_return_box(@changes.add_escape_box(genv, @arg.ret, e_ret))
+        e_ret = @lenv.locals[:"*expected_method_ret"]
+        @lenv.add_return_box(@changes.add_escape_box(genv, @arg.ret, e_ret)) if e_ret
         Source.new(Type::Bot.new(genv))
       end
     end

--- a/scenario/misc/define_method_return.rb
+++ b/scenario/misc/define_method_return.rb
@@ -1,0 +1,8 @@
+## update
+class Foo
+  define_method(:foo) { return }
+end
+
+## assert
+class Foo
+end


### PR DESCRIPTION
Currently TypeProf does not support `define_method`. A return statement in `define_method` is considered as a non-method-scope return, which is not well supported. This change temporarily ignores such a case.