### PR TITLE
Avoid wrong infinite loop

### DIFF
--- a/lib/typeprof/core/graph/vertex.rb
+++ b/lib/typeprof/core/graph/vertex.rb
@@ -28,14 +28,17 @@ module TypeProf::Core
         end
       end
 
+      return true if @types.empty?
       return true if vtx.types.empty?
 
       each_type do |ty|
-        next if vtx.types.include?(ty) # fast path
-        return false unless ty.check_match(genv, changes, vtx)
+        return true if vtx.types.include?(ty) # fast path
+        if ty.check_match(genv, changes, vtx)
+          return true
+        end
       end
 
-      return true
+      return false
     end
 
     def show

--- a/scenario/known-issues/check-return-type.rb
+++ b/scenario/known-issues/check-return-type.rb
@@ -1,6 +1,7 @@
 ## update: test.rbs
 class Foo
   def foo: -> Foo
+  def foo=: (Foo) -> Foo
 end
 
 ## update: test.rb
@@ -9,8 +10,8 @@ class Foo
     @foo = 1
   end
 
-  attr_reader :foo
+  attr_accessor :foo
 end
 
 ## diagnostics: test.rb
-(6,2)-(6,18): expected: Foo; actual: Integer
+(6,2)-(6,20): expected: Foo; actual: (Foo | Integer)

--- a/scenario/known-issues/unsupported-arg.rb
+++ b/scenario/known-issues/unsupported-arg.rb
@@ -1,0 +1,14 @@
+## update: test.rbs
+class Object
+  def foo: (String) -> String
+         | (Integer) -> Integer
+  def get1: -> (String | Integer)
+  def get2: -> (String | Integer | nil)
+end
+
+## update: test.rb
+def check1 = foo(get1)
+def check2 = foo(get2)
+
+## diagnostics
+(2,13)-(2,16): expected: (String | Integer); actual: (String | Integer)?

--- a/scenario/regressions/avoid-infinte-loop-2.rb
+++ b/scenario/regressions/avoid-infinte-loop-2.rb
@@ -1,0 +1,26 @@
+## update: test.rbs
+class Foo
+  def foo: -> Foo?
+  def self.bar: (Foo) -> Foo
+end
+
+## update: test.rb
+def check
+  # The old infinite-loop scenario
+  #  1. both @a and @b are untyped
+  #  2. @b is now Foo because `@b = Foo.bar(@a)` and `Foo.bar: (Foo) -> Foo` and @a is untyped
+  #  3. @a is now Foo? because of `@a = @b.foo` and @b is Foo
+  #  4. @b is now untyped because `@b = Foo.bar(@a)` and `Foo.bar: (Foo) -> Foo` and @a is Foo | nil
+  #  5. go to 2
+  #
+  # How did I fixed:
+  #  `Foo.bar: (Foo) -> Foo` should match against `Foo | nil`
+  #  (TODO: add a diagnostics for this)
+  @a = @b.foo
+  @b = Foo.bar(@a)
+end
+
+def check2
+  @a = @b[0]
+  @b = '/' + @a
+end


### PR DESCRIPTION
TypeProf caused an infinite loop under the following situation:

```
@a = @b[0]
@b = '/' + @a
```

1. both @a and @b is untyped
2. @b is changed to a String because of the second line (String#+)
3. @a is changed to a String? because of the first line (String#[])
4. @b is changed to nil because String#+ does not accept String?
5. go to 2

This change fixes the loop by making `String#+` to accept `String?`.

TODO: it should emit a warning, but it is a bot complex considering the situation where passing `Integer | String | nil` to the following foo:

```
def foo: (Integer) -> Integer
       | (String) -> String
``