### PR TITLE
Support flip flop operator

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -219,6 +219,7 @@ module TypeProf::Core
       when :for_node then ForNode.new(raw_node, lenv)
       when :alias_global_variable_node then AliasGlobalVariableNode.new(raw_node, lenv)
       when :post_execution_node then PostExecutionNode.new(raw_node, lenv)
+      when :flip_flop_node then FlipFlopNode.new(raw_node, lenv)
       when :shareable_constant_node
         create_node(raw_node.write, lenv)
 

--- a/lib/typeprof/core/ast/misc.rb
+++ b/lib/typeprof/core/ast/misc.rb
@@ -205,5 +205,23 @@ module TypeProf::Core
         Source.new(genv.nil_type)
       end
     end
+
+    class FlipFlopNode < Node
+      def initialize(raw_node, lenv)
+        super(raw_node, lenv)
+        @e1 = AST.create_node(raw_node.left, lenv)
+        @e2 = AST.create_node(raw_node.right, lenv)
+      end
+
+      attr_reader :e1, :e2
+
+      def subnodes = { e1:, e2: }
+
+      def install0(genv)
+        @e1.install(genv)
+        @e2.install(genv)
+        Source.new(genv.true_type, genv.false_type)
+      end
+    end
   end
 end

--- a/scenario/misc/flip_flop.rb
+++ b/scenario/misc/flip_flop.rb
@@ -1,0 +1,12 @@
+## update
+def foo
+  n = 3
+  if (n==2)..(n==2)
+    # flip_flop_node can not become a return value because it is only available in condition.
+  end
+end
+
+## assert
+class Object
+  def foo: -> nil
+end


### PR DESCRIPTION
Support flip flop operator.

From [flip flop document](https://docs.ruby-lang.org/ja/latest/doc/spec=2foperator.html#range_cond), I understand as following. If they are incorrect, please let me fix the code.
* The type of flip flop operator is True or False.
* This is only available in conditions.