### PR TITLE
Fix spec.bindir and spec.executables

### DIFF
--- a/typeprof.gemspec
+++ b/typeprof.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(doc|test|spec|features|smoke|testbed|vscode)/}) }
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rbs", ">= 3.5.1"


### PR DESCRIPTION
When I tried to use the latest TypeProf, I encountered the following error (I have updated the `required_ruby_version` to 3.3):

```
[vscode] Try to start TypeProf for IDE
[vscode] stderr: your 131072x1 screen size is bogus. expect trouble
[vscode] stderr: your 131072x1 screen size is bogus. expect trouble
[vscode] stderr: stty: 'standard input': Inappropriate ioctl for device
[vscode] stderr: bundler: failed to load command: typeprof (/home/iori/.asdf/installs/ruby/3.4.0-preview1/bin/typeprof)
[vscode] stderr: /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/rubygems_integration.rb:308:in 'block in Gem.replace_bin_path': can't find executable typeprof for gem typeprof (Gem::Exception)
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/rubygems_integration.rb:336:in 'block in Gem.replace_bin_path'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/bin/typeprof:25:in '<top (required)>'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:58:in 'Kernel.load'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:58:in 'Bundler::CLI::Exec#kernel_load'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/cli.rb:492:in 'Bundler::CLI#exec'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor/command.rb:27:in 'Bundler::Thor::Command#run'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor.rb:392:in 'Bundler::Thor.dispatch'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/cli.rb:34:in 'Bundler::CLI.dispatch'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/vendor/thor/lib/thor/base.rb:485:in 'Bundler::Thor::Base::ClassMethods#start'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/cli.rb:28:in 'Bundler::CLI.start'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/exe/bundle:45:in 'block in <top (required)>'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/lib/ruby/gems/3.4.0+0/gems/bundler-2.4.10/exe/bundle:33:in '<top (required)>'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/bin/bundle:25:in 'Kernel#load'
[vscode] stderr: 	from /home/iori/.asdf/installs/ruby/3.4.0-preview1/bin/bundle:25:in '<main>'
[vscode] failed to invoke typeprof: error code 1
[vscode] Ruby TypeProf is not configured
```

It seems that spec.bindir and spec.executables in the gemspec were incorrect, so I have fixed them.