### PR TITLE
Fix up gemspec.files

### DIFF
--- a/typeprof.gemspec
+++ b/typeprof.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(doc|test|spec|features|smoke|testbed|vscode)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(.devcontainer|.github|scenario|sig|test|tool)/}) } - [ ".gitignore", "Gemfile", "Gemfile.lock", "Rakefile", "typeprof.conf.json"]
   end
   spec.bindir        = "bin"
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
This patch makes gem include files below:

- LICENSE
- README.md
- bin/typeprof
- lib/*
- typeprof.gemspec