### PR TITLE
Support blank ensure statements.

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -366,8 +366,8 @@ module TypeProf::Core
           end
           raw_res = raw_res.subsequent
         end
-        @else_clause = raw_node.else_clause ? AST.create_node(raw_node.else_clause.statements, lenv) : DummyNilNode.new(code_range, lenv)
-        @ensure_clause = raw_node.ensure_clause ? AST.create_node(raw_node.ensure_clause.statements, lenv) : DummyNilNode.new(code_range, lenv)
+        @else_clause = raw_node.else_clause&.statements ? AST.create_node(raw_node.else_clause.statements, lenv) : DummyNilNode.new(code_range, lenv)
+        @ensure_clause = raw_node.ensure_clause&.statements ? AST.create_node(raw_node.ensure_clause.statements, lenv) : DummyNilNode.new(code_range, lenv)
       end
 
       attr_reader :body, :rescue_conds, :rescue_clauses, :else_clause, :ensure_clause

--- a/scenario/control/begin.rb
+++ b/scenario/control/begin.rb
@@ -60,3 +60,17 @@ end
 class Object
   def foo: -> (Integer | String | true)
 end
+
+## update
+def foo
+  begin
+  rescue
+  else
+  ensure
+  end
+end
+
+## assert
+class Object
+  def foo: -> nil
+end


### PR DESCRIPTION
Fixes a `NoMethodError` that occurred when a begin block included a blank ensure clause. Previously, attempting to handle such a statement resulted in the following error:

```
NoMethodError: undefined method `type' for nil
.../typeprof/lib/typeprof/core/ast.rb:24:in `create_node'
.../typeprof/lib/typeprof/core/ast/control.rb:369:in `initialize'
```

Related: https://github.com/test-unit/test-unit/blob/68c6c3a/lib/test/unit/testcase.rb#L623