### PR TITLE
fix: Resolve issue preventing CLI startup with `typeprof --lsp --stdio` option

### DIFF
--- a/lib/typeprof/cli/cli.rb
+++ b/lib/typeprof/cli/cli.rb
@@ -49,7 +49,7 @@ module TypeProf::CLI
 
       opt.parse!(argv)
 
-      if cli_options[:lsp] && !lsp_options.empty?
+      if !cli_options[:lsp] && !lsp_options.empty?
         raise OptionParser::InvalidOption.new("lsp options with non-lsp mode")
       end
 

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -110,5 +110,23 @@ module TypeProf
         end
       end)
     end
+
+    def test_lsp_options_with_lsp_mode
+      assert_nothing_raised { TypeProf::CLI::CLI.new(["--lsp", "--stdio"]) }
+    end
+
+    def test_lsp_options_with_non_lsp_mode
+      invalid_options = [
+        ["--stdio", "."],
+        ["--port", "123456", "."],
+      ]
+
+      invalid_options.each do |argv|
+        stdout, _stderr = capture_output do
+          assert_raises(SystemExit) { TypeProf::CLI::CLI.new(argv) }
+        end
+        assert_equal("invalid option: lsp options with non-lsp mode\n", stdout)
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit fixes a bug where the CLI would fail to start when invoked with the `typeprof --lsp --stdio` option.
