### PR TITLE
Move Prism dependency to gemspec file from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,6 @@ source "https://rubygems.org"
 #  gemspec
 #end
 
-gem "prism", ">= 1.0.0"
-
 group :development do
   gem "rake"
   gem "stackprof", platforms: :mri

--- a/typeprof.gemspec
+++ b/typeprof.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "rbs", ">= 3.6.0"
+  spec.add_runtime_dependency "prism", ">= 1.0.0"
 end


### PR DESCRIPTION
Using TypeProf as a library does not resolve `Gemfile` dependencies.  In particular, TypeProf uses the `start_code_units_column` method introduced in [Prism version 0.23.0](https://github.com/ruby/prism/releases/tag/v0.23.0), so it must be at least that version or later.