### PR TITLE
Add keyword arguments for severity and tags in Diagnostic

### DIFF
--- a/lib/typeprof/diagnostic.rb
+++ b/lib/typeprof/diagnostic.rb
@@ -1,18 +1,18 @@
 module TypeProf
   class Diagnostic
-    def initialize(node, meth, msg)
+    def initialize(node, meth, msg, severity: :error, tags: nil)
       @node = node
       @meth = meth
       @msg = msg
-      @severity = :error # TODO: keyword argument
-      @tags = nil # TODO: keyword argument
+      @severity = severity
+      @tags = tags
     end
 
     def reuse(new_node)
       @node = new_node
     end
 
-    attr_reader :msg, :severity
+    attr_reader :msg, :severity, :tags
 
     def code_range
       @node.send(@meth)

--- a/test/diagnostic_test.rb
+++ b/test/diagnostic_test.rb
@@ -1,0 +1,33 @@
+require_relative "helper"
+
+module TypeProf
+  class DiagnosticTest < Test::Unit::TestCase
+    class DummyNode
+      def code_range
+        nil
+      end
+    end
+
+    def test_diagnostic_with_default_values
+      diag = Diagnostic.new(DummyNode.new, :code_range, "test message")
+      assert_equal :error, diag.severity
+      assert_nil diag.tags
+    end
+
+    def test_diagnostic_with_custom_severity
+      diag = Diagnostic.new(DummyNode.new, :code_range, "test message", severity: :warning)
+      assert_equal :warning, diag.severity
+    end
+
+    def test_diagnostic_with_custom_tags
+      diag = Diagnostic.new(DummyNode.new, :code_range, "test message", tags: [:deprecated])
+      assert_equal [:deprecated], diag.tags
+    end
+
+    def test_diagnostic_with_custom_severity_and_tags
+      diag = Diagnostic.new(DummyNode.new, :code_range, "test message", severity: :info, tags: [:experimental])
+      assert_equal :info, diag.severity
+      assert_equal [:experimental], diag.tags
+    end
+  end
+end


### PR DESCRIPTION
## Changes
- Add severity and tags as keyword arguments to Diagnostic#initialize with default values
- Add attr_reader for tags attribute
- Add comprehensive test cases in new test/diagnostic_test.rb
- Remove TODO comments as the feature is now implemented

## Testing
Added test cases to verify:
- Default values (severity: error, tags: nil)
- Custom severity settings
- Custom tags settings
- Combined severity and tags settings