### PR TITLE
Make `untyped` not match any other type

### DIFF
--- a/lib/typeprof/core/graph/vertex.rb
+++ b/lib/typeprof/core/graph/vertex.rb
@@ -28,7 +28,6 @@ module TypeProf::Core
         end
       end
 
-      return true if @types.empty?
       return true if vtx.types.empty?
 
       each_type do |ty|

--- a/scenario/args/positionals_rb_to_rbs.rb
+++ b/scenario/args/positionals_rb_to_rbs.rb
@@ -18,7 +18,7 @@ def test_ok4
   foo("str", *ary)
 end
 def test_ok5
-  foo("str", *ary, 1, *ary, 2)
+  foo("str", *$untyped, 1, *$untyped, 2)
 end
 def test_ng1
   foo("str", "str")
@@ -27,7 +27,7 @@ def test_ng2
   foo("str", 1, 2, 3, "str")
 end
 def test_ng3
-  foo("str", *ary, "str")
+  foo("str", *$untyped, "str")
 end
 
 ## assert
@@ -37,10 +37,15 @@ class Object
   def test_ok3: -> :ok
   def test_ok4: -> :ok
   def test_ok5: -> :ok
-  def test_ng1: -> untyped
-  def test_ng2: -> untyped
-  def test_ng3: -> untyped
+  def test_ng1: -> :ok
+  def test_ng2: -> :ok
+  def test_ng3: -> :ok
 end
+
+## diagnostics
+(18,2)-(18,5): wrong type of arguments
+(21,2)-(21,5): wrong type of arguments
+(24,2)-(24,5): wrong type of arguments
 
 ## update: test.rbs
 class Object
@@ -66,9 +71,13 @@ end
 class Object
   def test_ok1: -> :ok
   def test_ok2: -> :ok
-  def test_ng1: -> untyped
-  def test_ng2: -> untyped
+  def test_ng1: -> :ok
+  def test_ng2: -> :ok
 end
+
+## diagnostics
+(8,2)-(8,5): wrong type of arguments
+(12,2)-(12,5): wrong type of arguments
 
 ## update: test.rbs
 class Object
@@ -110,11 +119,17 @@ class Object
   def test_ok2: -> :ok
   def test_ok3: -> :ok
   def test_ok4: -> :ok
-  def test_ng1: -> untyped
-  def test_ng2: -> untyped
-  def test_ng3: -> untyped
-  def test_ng4: -> untyped
+  def test_ng1: -> :ok
+  def test_ng2: -> :ok
+  def test_ng3: -> :ok
+  def test_ng4: -> :ok
 end
+
+## diagnostics
+(15,2)-(15,5): wrong type of arguments
+(18,2)-(18,5): wrong type of arguments
+(22,2)-(22,5): wrong type of arguments
+(26,2)-(26,5): wrong type of arguments
 
 ## update: test.rbs
 class Object
@@ -139,5 +154,8 @@ end
 class Object
   def test_ok1: -> :ok
   def test_ok2: -> :ok
-  def test_ng1: -> untyped
+  def test_ng1: -> :ok
 end
+
+## diagnostics
+(11,2)-(11,5): wrong type of arguments

--- a/scenario/incremental/basic1.rb
+++ b/scenario/incremental/basic1.rb
@@ -25,5 +25,8 @@ end
 
 ## assert: test0.rb
 class Object
-  def foo: (String) -> untyped
+  def foo: (String) -> String
 end
+
+## diagnostics: test0.rb
+(2,4)-(2,5): wrong type of arguments

--- a/scenario/incremental/basic3.rb
+++ b/scenario/incremental/basic3.rb
@@ -24,6 +24,6 @@ end
 
 ## assert
 class Object
-  def foo: (String) -> untyped
-  def main: -> untyped
+  def foo: (String) -> String
+  def main: -> String
 end

--- a/scenario/rbs/block.rb
+++ b/scenario/rbs/block.rb
@@ -28,9 +28,15 @@ end
 ## assert
 class Object
   def test1: -> :ok
-  def test2: -> untyped
+  def test2: -> :ok
   def test3: -> :ok
   def test4: -> :ok
-  def test5: -> untyped
+  def test5: -> :ok
   def test6: -> :ok
 end
+
+## diagnostics
+(5,2)-(5,10): block is not expected
+(11,2)-(11,20): expected: Integer; actual: nil
+(14,2)-(14,16): block is expected
+(17,2)-(17,20): expected: Integer; actual: nil

--- a/scenario/rbs/change-superclass.rb
+++ b/scenario/rbs/change-superclass.rb
@@ -18,8 +18,11 @@ end
 class B
 end
 class Object
-  def test: -> untyped
+  def test: -> :foo_a
 end
+
+## diagnostics: test.rb
+(6,6)-(6,9): wrong type of arguments
 
 ## update: test.rb
 class A
@@ -38,3 +41,5 @@ end
 class Object
   def test: -> :foo_a
 end
+
+## diagnostics: test.rb

--- a/scenario/rbs/change-superclass2.rb
+++ b/scenario/rbs/change-superclass2.rb
@@ -44,19 +44,27 @@ class Object
   def test_a_b: -> :a
   def test_a_c: -> :a
   def test_a_d: -> :a
-  def test_b_a: -> untyped
+  def test_b_a: -> :b
   def test_b_b: -> :b
   def test_b_c: -> :b
   def test_b_d: -> :b
-  def test_c_a: -> untyped
-  def test_c_b: -> untyped
+  def test_c_a: -> :c
+  def test_c_b: -> :c
   def test_c_c: -> :c
   def test_c_d: -> :c
-  def test_d_a: -> untyped
-  def test_d_b: -> untyped
-  def test_d_c: -> untyped
+  def test_d_a: -> :d
+  def test_d_b: -> :d
+  def test_d_c: -> :d
   def test_d_d: -> :d
 end
+
+## diagnostics: test.rb
+(7,15)-(7,23): wrong type of arguments
+(12,15)-(12,23): wrong type of arguments
+(13,15)-(13,23): wrong type of arguments
+(17,15)-(17,23): wrong type of arguments
+(18,15)-(18,23): wrong type of arguments
+(19,15)-(19,23): wrong type of arguments
 
 ## update: test.rbs
 class A
@@ -74,18 +82,29 @@ end
 class Object
   def test_a_a: -> :a
   def test_a_b: -> :a
-  def test_a_c: -> untyped
+  def test_a_c: -> :a
   def test_a_d: -> :a
-  def test_b_a: -> untyped
+  def test_b_a: -> :b
   def test_b_b: -> :b
-  def test_b_c: -> untyped
+  def test_b_c: -> :b
   def test_b_d: -> :b
-  def test_c_a: -> untyped
-  def test_c_b: -> untyped
+  def test_c_a: -> :c
+  def test_c_b: -> :c
   def test_c_c: -> :c
-  def test_c_d: -> untyped
-  def test_d_a: -> untyped
-  def test_d_b: -> untyped
-  def test_d_c: -> untyped
+  def test_c_d: -> :c
+  def test_d_a: -> :d
+  def test_d_b: -> :d
+  def test_d_c: -> :d
   def test_d_d: -> :d
 end
+
+## diagnostics: test.rb
+(4,15)-(4,23): wrong type of arguments
+(7,15)-(7,23): wrong type of arguments
+(9,15)-(9,23): wrong type of arguments
+(12,15)-(12,23): wrong type of arguments
+(13,15)-(13,23): wrong type of arguments
+(15,15)-(15,23): wrong type of arguments
+(17,15)-(17,23): wrong type of arguments
+(18,15)-(18,23): wrong type of arguments
+(19,15)-(19,23): wrong type of arguments

--- a/scenario/rbs/symbol.rb
+++ b/scenario/rbs/symbol.rb
@@ -24,7 +24,10 @@ end
 ## assert
 class Object
   def test1: -> :ok
-  def test2: -> untyped
+  def test2: -> :ok
   def test3: -> :ok
   def test4: -> :ok
 end
+
+## diagnostics
+(6,8)-(6,11): wrong type of arguments

--- a/scenario/rbs/type-alias.rb
+++ b/scenario/rbs/type-alias.rb
@@ -25,6 +25,9 @@ class Object
   def test3: (untyped) -> (Integer | String)
 end
 
+## diagnostics: test.rb
+(10,10)-(10,13): wrong type of arguments
+
 ## update: test.rbs
 type a = Integer
 class Foo
@@ -35,9 +38,13 @@ end
 ## assert: test.rb
 class Object
   def test1: -> Integer
-  def test2: -> untyped
+  def test2: -> Integer
   def test3: (untyped) -> Integer
 end
+
+## diagnostics: test.rb
+(6,10)-(6,13): wrong type of arguments
+(10,10)-(10,13): wrong type of arguments
 
 ## update: test.rbs
 type a = Integer
@@ -48,9 +55,13 @@ end
 ## assert: test.rb
 class Object
   def test1: -> Integer
-  def test2: -> untyped
+  def test2: -> Integer
   def test3: (untyped) -> Integer
 end
+
+## diagnostics: test.rb
+(6,10)-(6,13): wrong type of arguments
+(10,10)-(10,13): wrong type of arguments
 
 ## update: test.rbs
 class Bar
@@ -63,6 +74,10 @@ end
 ## assert: test.rb
 class Object
   def test1: -> Integer
-  def test2: -> untyped
+  def test2: -> Integer
   def test3: (untyped) -> Integer
 end
+
+## diagnostics: test.rb
+(6,10)-(6,13): wrong type of arguments
+(10,10)-(10,13): wrong type of arguments

--- a/scenario/rbs/untyped-for-overload.rb
+++ b/scenario/rbs/untyped-for-overload.rb
@@ -1,0 +1,15 @@
+## update: test.rbs
+class C
+  def foo: (:a) -> :A
+         | (:b) -> :B
+end
+
+## update: test.rb
+def check
+  C.new.foo($untyped)
+end
+
+## assert
+class Object
+  def check: -> untyped
+end

--- a/scenario/regressions/avoid-infinite-loop-4.rb
+++ b/scenario/regressions/avoid-infinite-loop-4.rb
@@ -1,0 +1,12 @@
+## update: test.rbs
+class C
+  def foo: (C) -> C
+  def bar: -> String
+end
+
+## update: test.rb
+def check
+  c = C.new
+  @a = @b.bar
+  @b = c.foo(@a)
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -32,7 +32,7 @@ module TypeProf
 
         # ./type_error.rb
         class Object
-          def check: -> untyped
+          def check: -> :ok
         end
       END
 
@@ -40,9 +40,9 @@ module TypeProf
         # TypeProf #{ TypeProf::VERSION }
 
         # ./type_error.rb
-        # (2,10)-(2,20):failed to resolve overloads
+        # (2,10)-(2,20):wrong type of arguments
         class Object
-          def check: -> untyped
+          def check: -> :ok
         end
       END
     end


### PR DESCRIPTION
So far, we have assumed that `untyped` matches any type. This approach had a problem that when an argument is untyped, it matches a method signature, and when the argument is any concrete type, it does not match the same method signature, and if the result of the match affects the type of the argument itself, the analysis would oscillate and loop endlessly.

This change makes `untyped` not match any other type. This will have a significant difference from gradutal typing's `untyped` (or `any`). Instead, we suppress diagnostics like `expected: C, actual: untyped`. We expect that this will not make much difference on the user side.

By assuming that untyped does not match a concrete type, it is expected that the scope of analysis will be narrower (not enough analysis can be done after the method call that fails to resolve overload). Therefore, we decided that if there is no overload in the method signature, the method signature will always be chosen (errors will be reported if there is a discrepancy in the type or number of arguments). This is expected to allow many method calls to be parsed with concrete types afterwards, even if there are discrepancies in arguments.