### PR TITLE
Replace unused instance variables with local variables

### DIFF
--- a/lib/typeprof/core/ast/module.rb
+++ b/lib/typeprof/core/ast/module.rb
@@ -61,8 +61,8 @@ module TypeProf::Core
           @tbl.each {|var| @body.lenv.locals[var] = Source.new(genv.nil_type) }
           @body.lenv.locals[:"*self"] = @body.lenv.cref.get_self(genv)
 
-          @mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@static_cpath)))
-          @changes.add_edge(genv, @mod_val, @mod_cdef.vtx)
+          mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@static_cpath)))
+          @changes.add_edge(genv, mod_val, @mod_cdef.vtx)
           ret = Vertex.new(self)
           @changes.add_edge(genv, @body.install(genv), ret)
           ret

--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -52,8 +52,8 @@ module TypeProf::Core
       end
 
       def install0(genv)
-        @mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@cpath)))
-        @changes.add_edge(genv, @mod_val, @static_ret[:module].vtx)
+        mod_val = Source.new(Type::Singleton.new(genv, genv.resolve_cpath(@cpath)))
+        @changes.add_edge(genv, mod_val, @static_ret[:module].vtx)
         @members.each do |member|
           member.install(genv)
         end


### PR DESCRIPTION
Replace `@mod_val` with a local variable since it's not used elsewhere