### PR TITLE
Support `(class << self; self; end)` syntax used in Minitest

### DIFF
--- a/scenario/class/singleton_class.rb
+++ b/scenario/class/singleton_class.rb
@@ -35,3 +35,15 @@ end
 class Foo < Bar
   def self.foo: -> :ok
 end
+
+## update
+class Foo
+  def self.foo
+    (class << self; self; end)
+  end
+end
+
+## assert
+class Foo
+  def self.foo: -> untyped
+end


### PR DESCRIPTION
`define_copy` had an error because `@mod_cdef` was not present. Rewrote to re-register module_def process.

```
typeprof/lib/typeprof/core/ast/module.rb:44:in 'TypeProf::Core::AST::ModuleBaseNode#define_copy': undefined method 'add_def' for nil (NoMethodError)

          @mod_cdef.add_def(self)
                   ^^^^^^^^
from typeprof/lib/typeprof/core/ast/base.rb:68:in 'block in TypeProf::Core::AST::Node#define_copy'
```