### PR TITLE
Support for implicit rest arguments in array patterns for repl_type_completor

### DIFF
--- a/lib/typeprof/core/ast/pattern.rb
+++ b/lib/typeprof/core/ast/pattern.rb
@@ -5,7 +5,15 @@ module TypeProf::Core
         super(raw_node, lenv)
         @requireds = raw_node.requireds.map {|raw_pat| AST.create_pattern_node(raw_pat, lenv) }
         @rest = !!raw_node.rest
-        @rest_pattern = raw_node.rest && raw_node.rest.expression ? AST.create_pattern_node(raw_node.rest.expression, lenv) : nil
+        @rest_pattern = case raw_node.rest
+                        when Prism::SplatNode
+                          AST.create_pattern_node(raw_node.rest.expression, lenv) if raw_node.rest.expression
+                        when Prism::ImplicitRestNode, nil
+                          nil
+                        else
+                          raise
+                        end
+
         @posts = raw_node.posts.map {|raw_pat| AST.create_pattern_node(raw_pat, lenv) }
       end
 

--- a/scenario/patterns/array_pat.rb
+++ b/scenario/patterns/array_pat.rb
@@ -12,6 +12,8 @@ def check(x)
     :baz # TODO: this should be excluded
   in MyArray[1, 2, 3]
     :qux
+  in [1,]
+    :waldo
   else
     :zzz
   end
@@ -23,5 +25,5 @@ check([1].to_a)
 class MyArray
 end
 class Object
-  def check: (Array[Integer]) -> (:bar | :baz | :foo | :qux | :zzz)
+  def check: (Array[Integer]) -> (:bar | :baz | :foo | :qux | :waldo | :zzz)
 end


### PR DESCRIPTION
Fix the following error:

```
Error: test: scenario/patterns/array_pat.rb(ScenarioCompiler::ScenarioTest): NoMethodError: undefined method 'expression' for an instance of Prism::ImplicitRestNode

lib/typeprof/core/ast/pattern.rb:8:in 'TypeProf::Core::AST::ArrayPatternNode#initialize'
```