### PR TITLE
Support `it`

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -92,6 +92,8 @@ module TypeProf::Core
       # variables
       when :local_variable_read_node
         LocalVariableReadNode.new(raw_node, lenv)
+      when :it_local_variable_read_node
+        ItLocalVariableReadNode.new(raw_node, lenv)
       when :local_variable_write_node
         LocalVariableWriteNode.new(raw_node, AST.create_node(raw_node.value, lenv), lenv)
       when :local_variable_operator_write_node

--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -55,6 +55,8 @@ module TypeProf::Core
                               raw_block.parameters.parameters.requireds.map {|n| n.is_a?(Prism::MultiTargetNode) ? nil : n.name }
                             when Prism::NumberedParametersNode
                               1.upto(raw_block.parameters.maximum).map { |n| :"_#{n}" }
+                            when Prism::ItParametersNode
+                              [:it]
                             when nil
                               []
                             else

--- a/lib/typeprof/core/ast/variable.rb
+++ b/lib/typeprof/core/ast/variable.rb
@@ -19,6 +19,22 @@ module TypeProf::Core
       end
     end
 
+    class ItLocalVariableReadNode < Node
+      def initialize(raw_node, lenv)
+        super(raw_node, lenv)
+      end
+
+      def attrs = {}
+
+      def install0(genv)
+        @lenv.get_var(:it)
+      end
+
+      def retrieve_at(pos)
+        yield self if code_range.include?(pos)
+      end
+    end
+
     class LocalVariableWriteNode < Node
       def initialize(raw_node, rhs, lenv)
         super(raw_node, lenv)

--- a/scenario/block/it.rb
+++ b/scenario/block/it.rb
@@ -1,0 +1,13 @@
+## update
+def foo(&b)
+  b.call(1)
+end
+
+foo do
+  it
+end
+
+## assert
+class Object
+  def foo: { (Integer) -> Integer } -> Integer
+end


### PR DESCRIPTION
TypeProf currently supports `_1` as a block parameter.
This PR also adds support for `it`.
