### PR TITLE
Add `# typeprof:disable/enable` directive for silencing diagnostics

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -15,7 +15,8 @@ module TypeProf::Core
       cref = CRef::Toplevel
       lenv = LocalEnv.new(path, cref, {}, [])
 
-      ProgramNode.new(raw_scope, lenv)
+      disable_ranges = TypeProf::Diagnostic::DisableDirective::Scanner.collect(result, src)
+      ProgramNode.new(raw_scope, lenv, disable_ranges: disable_ranges)
     end
 
     #: (untyped, TypeProf::Core::LocalEnv, ?bool) -> TypeProf::Core::AST::Node

--- a/lib/typeprof/diagnostic.rb
+++ b/lib/typeprof/diagnostic.rb
@@ -1,3 +1,5 @@
+require_relative "./diagnostic/disable_directive/scanner"
+
 module TypeProf
   class Diagnostic
     def initialize(node, meth, msg, tags: nil)

--- a/lib/typeprof/diagnostic.rb
+++ b/lib/typeprof/diagnostic.rb
@@ -1,4 +1,5 @@
 require_relative "./diagnostic/disable_directive/scanner"
+require_relative "./diagnostic/disable_directive/filter"
 
 module TypeProf
   class Diagnostic

--- a/lib/typeprof/diagnostic/disable_directive/filter.rb
+++ b/lib/typeprof/diagnostic/disable_directive/filter.rb
@@ -1,0 +1,16 @@
+module TypeProf
+  class Diagnostic
+    module DisableDirective
+      # Determine which diagnostic ranges should not be reported.
+      class Filter
+        def initialize(ranges)
+          @ranges = ranges
+        end
+
+        def skip?(line)
+          @ranges.any? { |r| r.cover?(line) }
+        end
+      end
+    end
+  end
+end

--- a/lib/typeprof/diagnostic/disable_directive/scanner.rb
+++ b/lib/typeprof/diagnostic/disable_directive/scanner.rb
@@ -1,0 +1,66 @@
+module TypeProf
+  class Diagnostic
+    module DisableDirective
+      # Determine which diagnostic ranges should not be reported.
+      #
+      # This scanner processes comments in the source code to identify which lines should be excluded from diagnostics.
+      # It supports both block-level and inline disable/enable comments.
+      #
+      # Block-level comments start with `# typeprof:disable` and end with `# typeprof:enable`.
+      # Inline comments with `# typeprof:disable` exclude diagnostics only for the line containing the comment.
+      class Scanner
+        DISABLE_RE = /\s*#\stypeprof:disable$/
+        ENABLE_RE = /\s*#\stypeprof:enable$/
+
+        def self.collect(prism_result, src)
+          lines = src.lines
+          comments_by_line = Hash.new { |h, k| h[k] = [] }
+
+          prism_result.comments.each do |c|
+            comments_by_line[c.location.start_line] << c.location.slice
+          end
+
+          ranges = []
+          current_start = nil
+
+          1.upto(lines.size) do |ln|
+            comment_text = comments_by_line[ln].join(' ')
+            line_text = lines[ln - 1]
+
+            disable = (comment_text =~ DISABLE_RE) || (line_text =~ DISABLE_RE)
+            enable = (comment_text =~ ENABLE_RE) || (line_text =~ ENABLE_RE)
+
+            if current_start # Inside a disable comment block.
+              if enable # Enable comment found.
+                ranges << (current_start..ln - 1)
+                if line_text.strip.start_with?('#') # Block-level enable comment found.
+                  current_start = nil # Close the disable comment block.
+                else
+                  # Inline enable comment found.
+                  # Exclude lines from the start of the disable comment block up to the current line.
+                  current_start = ln + 1 # Start a new disable comment block on the next line.
+                end
+              end
+            else
+              # Outside a disable comment block.
+              next unless disable
+
+              if line_text.strip.start_with?('#') # Block-level disable comment found.
+                current_start = ln + 1 # Disable comment block starts on the next line.
+              else
+                # Inline disable comment found.
+                ranges << (ln..ln) # Exclude only the current line with inline disable.
+              end
+            end
+          end
+
+          # If a disable comment block was started but no matching enable comment was found,
+          # exclude all lines from the start of the disable comment block to the end of the file.
+          ranges << (current_start..Float::INFINITY) if current_start && current_start <= lines.size
+
+          ranges
+        end
+      end
+    end
+  end
+end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -47,6 +47,17 @@ module TypeProf
       END
     end
 
+    def test_e2e_disable_directive
+      assert_equal(<<~END, test_run("disable_directive", ["--show-error", "."]))
+        # TypeProf #{ TypeProf::VERSION }
+
+        # ./disable_directive.rb
+        class Object
+          def check: -> :ok
+        end
+      END
+    end
+
     def test_e2e_syntax_error
       assert_equal(<<~END, test_run("syntax_error", ["."]))
         # TypeProf #{ TypeProf::VERSION }

--- a/test/diagnostic/disable_directive/filter_test.rb
+++ b/test/diagnostic/disable_directive/filter_test.rb
@@ -1,0 +1,41 @@
+require_relative '../../helper'
+
+module TypeProf
+  class Diagnostic
+    module DisableDirective
+      class FilterTest < Test::Unit::TestCase
+        def test_skip_when_line_is_in_range
+          ranges = [1..3]
+          filter = Filter.new(ranges)
+
+          assert_equal(true, filter.skip?(1))
+          assert_equal(true, filter.skip?(2))
+          assert_equal(true, filter.skip?(3))
+        end
+
+        def test_not_ignore_when_line_is_not_in_range
+          ranges = [2..3]
+          filter = Filter.new(ranges)
+
+          assert_equal(false, filter.skip?(1))
+          assert_equal(false, filter.skip?(4))
+        end
+
+        def test_with_empty_ranges
+          filter = Filter.new([])
+
+          assert_equal(false, filter.skip?(1))
+        end
+
+        def test_with_infinite_range
+          ranges = [2..Float::INFINITY]
+          filter = Filter.new(ranges)
+
+          assert_equal(false, filter.skip?(1))
+          assert_equal(true, filter.skip?(2))
+          assert_equal(true, filter.skip?(100))
+        end
+      end
+    end
+  end
+end

--- a/test/diagnostic/disable_directive/scanner_test.rb
+++ b/test/diagnostic/disable_directive/scanner_test.rb
@@ -1,0 +1,132 @@
+require_relative '../../helper'
+
+module TypeProf
+  class Diagnostic
+    module DisableDirective
+      class ScannerTest < Test::Unit::TestCase
+        def test_when_no_directives
+          src = <<~RUBY
+            def foo
+              x = 1
+              y = 2
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_empty ranges
+        end
+
+        def test_when_only_inline_enable_comment
+          src = <<~RUBY
+            def foo
+              x = 1 # typeprof:enable
+              y = 2
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 0, ranges.size
+        end
+
+        def test_when_only_inline_disable_comment
+          src = <<~RUBY
+            def foo
+              x = 1 # typeprof:disable
+              y = 2
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 1, ranges.size
+          assert_equal (2..2), ranges[0]
+        end
+
+        def test_when_only_block_disable_comment
+          src = <<~RUBY
+            def foo
+              # typeprof:disable
+              x = 1
+              y = 2
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 1, ranges.size
+          assert_equal (3..Float::INFINITY), ranges[0]
+        end
+
+        def test_when_only_block_disable_and_enable_comment
+          src = <<~RUBY
+            def foo
+              # typeprof:disable
+              x = 1
+              y = 2
+              # typeprof:enable
+              z = 3
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 1, ranges.size
+          assert_equal (3..4), ranges.first
+        end
+
+        def test_when_inline_disable_comment
+          src = <<~RUBY
+            def foo
+              x = 1 # typeprof:disable
+              y = 2
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 1, ranges.size
+          assert_equal (2..2), ranges[0]
+        end
+
+        def test_when_only_block_disable_and_inline_enable_comment
+          src = <<~RUBY
+            def foo
+              # typeprof:disable
+              x = 1
+              y = 2
+              z = 3 # typeprof:enable
+              w = 4
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 2, ranges.size
+          assert_equal (3..4), ranges[0]
+          assert_equal (6..Float::INFINITY), ranges[1]
+        end
+
+        def test_when_multiple_comments
+          src = <<~RUBY
+            def foo
+              # typeprof:disable
+              x = 1
+              # typeprof:enable
+              y = 2
+              z = 3 # typeprof:disable
+              w = 4
+            end
+          RUBY
+          prism_result = Prism.parse(src)
+          ranges = Scanner.collect(prism_result, src)
+
+          assert_equal 2, ranges.size
+          assert_equal (3..3), ranges[0]
+          assert_equal (6..6), ranges[1]
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/disable_directive/disable_directive.rb
+++ b/test/fixtures/disable_directive/disable_directive.rb
@@ -1,0 +1,3 @@
+def check
+  Foo.new.accept_int("str") # typeprof:disable
+end

--- a/test/fixtures/disable_directive/disable_directive.rbs
+++ b/test/fixtures/disable_directive/disable_directive.rbs
@@ -1,0 +1,3 @@
+class Foo
+  def accept_int: (Integer) -> :ok
+end


### PR DESCRIPTION
## Overview  
This PR adds RuboCop‑style comment directives that let users silence TypeProf diagnostics.

```ruby
foo(1, 2) # typeprof:disable           # inline – only this line

# typeprof:disable                     # block start
foo(1, 2)
bar(1, 2)
# typeprof:enable                      # block end
```

The feature works in CLI and **LSP modes  
![CleanShot 2025-04-19 at 21 30 44](https://github.com/user-attachments/assets/ca00f5fc-0f9b-4063-af6f-9f86cab6da3a)
![CleanShot 2025-04-19 at 21 29 16](https://github.com/user-attachments/assets/352b0175-f7aa-412a-b10b-9e012e97ac10)

---

## Implementation notes
* **`Diagnostic::DisableDirective::Scanner`** – parses comments and returns muted line ranges.  
* **`Diagnostic::DisableDirective::Filter`** – determines whether a diagnostic should be reported.  
* **`ProgramNode#diagnostics`** applies the filter. I implemented the filtering logic in ProgramNode, but please let me know if there is a better way.

---

## Related issue  
Closes [#108](https://github.com/ruby/typeprof/issues/108)