### PR TITLE
Fix rescue-assign.rb test case to expect String return type

### DIFF
--- a/scenario/control/rescue-assign.rb
+++ b/scenario/control/rescue-assign.rb
@@ -12,5 +12,5 @@ foo(1)
 
 ## assert
 class Object
-  def foo: (Integer) -> String?
+  def foo: (Integer) -> String
 end


### PR DESCRIPTION
The tests are failing on the master branch.
As I see it, I think `#foo` will never return nil.