### PR TITLE
Fixed typeprof.conf.json could not be loaded on VSCode on Windows

### DIFF
--- a/lib/typeprof/lsp/server.rb
+++ b/lib/typeprof/lsp/server.rb
@@ -69,7 +69,13 @@ module TypeProf::LSP
     end
 
     def uri_to_path(url)
-      url.delete_prefix(@url_schema)
+      path = url.delete_prefix(@url_schema)
+
+      if path.include?('%3A')
+        path.sub(/%3A/, ':')
+      else
+        path
+      end
     end
 
     #: (Array[String]) -> void

--- a/lib/typeprof/lsp/server.rb
+++ b/lib/typeprof/lsp/server.rb
@@ -1,3 +1,5 @@
+require "cgi"
+
 module TypeProf::LSP
   module ErrorCodes
     ParseError = -32700
@@ -69,13 +71,7 @@ module TypeProf::LSP
     end
 
     def uri_to_path(url)
-      path = url.delete_prefix(@url_schema)
-
-      if path.include?('%3A')
-        path.sub(/%3A/, ':')
-      else
-        path
-      end
+      CGI.unescape_uri_component(url.delete_prefix(@url_schema))
     end
 
     #: (Array[String]) -> void

--- a/lib/typeprof/lsp/server.rb
+++ b/lib/typeprof/lsp/server.rb
@@ -67,11 +67,11 @@ module TypeProf::LSP
 
     #: (String) -> String
     def path_to_uri(path)
-      @url_schema + File.expand_path(path)
+      @url_schema + File.expand_path(path).split("/").map {|s| CGI.escape_uri_component(s) }.join("/")
     end
 
-    def uri_to_path(url)
-      CGI.unescape_uri_component(url.delete_prefix(@url_schema))
+    def uri_to_path(uri)
+      uri.delete_prefix(@url_schema).split("/").map {|s| CGI.unescape_uri_component(s) }.join("/")
     end
 
     #: (Array[String]) -> void

--- a/lib/typeprof/lsp/server.rb
+++ b/lib/typeprof/lsp/server.rb
@@ -67,11 +67,11 @@ module TypeProf::LSP
 
     #: (String) -> String
     def path_to_uri(path)
-      @url_schema + File.expand_path(path).split("/").map {|s| CGI.escape_uri_component(s) }.join("/")
+      @url_schema + File.expand_path(path).split("/").map {|s| CGI.escapeURIComponent(s) }.join("/")
     end
 
     def uri_to_path(uri)
-      uri.delete_prefix(@url_schema).split("/").map {|s| CGI.unescape_uri_component(s) }.join("/")
+      uri.delete_prefix(@url_schema).split("/").map {|s| CGI.unescapeURIComponent(s) }.join("/")
     end
 
     #: (Array[String]) -> void


### PR DESCRIPTION
The problem was that the `url` processed by `uri_to_path` was like `c%3A/Users/shunh/vscode-typeprof-test`, and typeprof.conf.json could not be loaded.

This meant that TypeProf could be launched as an LSP, but the results of type analysis were not displayed on VSCode.

So, I changed that if `%3A` is included in the url returned by `uri_to_path`, it is replaced with `:`.
However, if you have any other good ways to fix it, please comment.

Note:
- Environment
  - OS: Windows 11
  - Ruby: Ruby 3.4.3(installed by RubyInstaller)
  - VSCode 1.99.3