### PR TITLE
Reflects changes in the ensure clause in BeginNode

### DIFF
--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -487,7 +487,20 @@ module TypeProf::Core
           end
         end
 
-        @ensure_clause.install(genv) if @ensure_clause
+        if @ensure_clause
+          ensure_old_vtxs = {}
+          vars.each do |var|
+            ensure_old_vtxs[var] = @lenv.get_var(var)
+          end
+
+          @ensure_clause.install(genv)
+
+          clause_vtxs_list << {}
+          vars.each do |var|
+            clause_vtxs_list.last[var] = @lenv.get_var(var)
+            @lenv.set_var(var, ensure_old_vtxs[var])
+          end
+        end
 
         result_vtxs = {}
         vars.each do |var|

--- a/scenario/control/begin-variable-tracking.rb
+++ b/scenario/control/begin-variable-tracking.rb
@@ -8,11 +8,11 @@ def foo
   rescue
     check_rescue(x)
     x = :d
-  # ensure # TODO: Looks like commenting out these two lines makes the test fail? Need to fix
-  #   x = :f
   else
     check_else(x)
     x = :e
+  ensure
+    x = :f
   end
   check_after(x)
 end
@@ -26,5 +26,5 @@ class Object
   def foo: -> nil
   def check_rescue: (:a | :c) -> nil
   def check_else: (:c) -> nil
-  def check_after: (:a | :c | :d | :e) -> nil
+  def check_after: (:a | :c | :d | :e | :f) -> nil
 end


### PR DESCRIPTION
This PR enables changes in the beginNode to be reflected in the ensure clause.
https://github.com/ruby/typeprof/pull/298#discussion_r2055747324