### PR TITLE
Update Prism to 1.4.0 and remove workarounds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ source "https://rubygems.org"
 #  gemspec
 #end
 
-gem "prism", ">= 1.0.0"
+gem "prism", ">= 1.4.0"
 
 group :development do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     docile (1.4.0)
     logger (1.6.0)
     power_assert (2.0.3)
-    prism (1.0.0)
+    prism (1.4.0)
     rake (13.2.1)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -30,7 +30,7 @@ PLATFORMS
 
 DEPENDENCIES
   coverage-helpers
-  prism (>= 1.0.0)
+  prism (>= 1.4.0)
   rake
   rbs!
   simplecov
@@ -39,4 +39,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   2.6.0.dev
+   2.6.8

--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -346,8 +346,7 @@ module TypeProf::Core
           break
         when :constant_path_node, :constant_path_target_node
           if raw_node.parent
-            # temporarily support old Prism https://bugs.ruby-lang.org/issues/20467
-            names << (raw_node.respond_to?(:name) ? raw_node.name : raw_node.child.name)
+            names << raw_node.name
             raw_node = raw_node.parent
           else
             return names.reverse

--- a/lib/typeprof/core/ast/const.rb
+++ b/lib/typeprof/core/ast/const.rb
@@ -17,14 +17,8 @@ module TypeProf::Core
             @cbase = nil
             @toplevel = true
           end
-          # temporarily support old Prism https://bugs.ruby-lang.org/issues/20467
-          if raw_node.respond_to?(:name)
-            @cname = raw_node.name
-            @cname_code_range = TypeProf::CodeRange.from_node(raw_node.name_loc)
-          else
-            @cname = raw_node.child.name
-            @cname_code_range = TypeProf::CodeRange.from_node(raw_node.child.location)
-          end
+          @cname = raw_node.name
+          @cname_code_range = TypeProf::CodeRange.from_node(raw_node.name_loc)
         else
           raise raw_node.type.to_s
         end


### PR DESCRIPTION
This PR updates the Prism dependency from 1.0.0 to 1.4.0 and removes workarounds that were needed for the old version. 