### PR TITLE
Remove Ruby 3.2 support from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby-truffleruby
-      min_version: 3.2
+      min_version: 3.3
 
   build:
     needs: ruby-versions


### PR DESCRIPTION
TypeProf supports Ruby 3.3 or later, so we can remove Ruby 3.2 from our CI matrix.