### PR TITLE
Fix typo in MatchPredicateNode class name

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -226,7 +226,7 @@ module TypeProf::Core
       when :flip_flop_node then FlipFlopNode.new(raw_node, lenv)
       when :shareable_constant_node then create_node(raw_node.write, lenv)
       when :match_required_node then MatchRequiredNode.new(raw_node, lenv)
-      when :match_predicate_node then MatchPreidcateNode.new(raw_node, lenv)
+      when :match_predicate_node then MatchPredicateNode.new(raw_node, lenv)
 
       # call
       when :super_node then SuperNode.new(raw_node, lenv)

--- a/lib/typeprof/core/ast/misc.rb
+++ b/lib/typeprof/core/ast/misc.rb
@@ -242,7 +242,7 @@ module TypeProf::Core
       end
     end
 
-    class MatchPreidcateNode < Node
+    class MatchPredicateNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
         @value = AST.create_node(raw_node.value, lenv)


### PR DESCRIPTION
Fix typo in `MatchPredicateNode` class name