### PR TITLE
Remove unnecessary comment out of typeDefinitionProvider

### DIFF
--- a/lib/typeprof/lsp/messages.rb
+++ b/lib/typeprof/lsp/messages.rb
@@ -91,7 +91,6 @@ module TypeProf::LSP
               "typeprof.disableSignature",
             ],
           },
-          #typeDefinitionProvider: true,
           referencesProvider: true,
         },
         serverInfo: {


### PR DESCRIPTION
typeDefinitionProvider property is commented out in the following commit when introducing LSP. 
https://github.com/ruby/typeprof/commit/239b01b90202095bc5612c82b99162f7b1cbd865

typeDefinitionProvider seems to be enabled when introduce type definition jump. 
https://github.com/ruby/typeprof/commit/618522e7c3b5f6b2d152be16b00f63e325dffcf1

This comment out is probably unnecessary and I remove it.