### PR TITLE
Support RBS::AST::Members::InstanceVariable

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -413,6 +413,8 @@ module TypeProf::Core
         SigAttrAccessorNode.new(raw_decl, lenv)
       when RBS::AST::Declarations::Base
         self.create_rbs_decl(raw_decl, lenv)
+      when RBS::AST::Members::InstanceVariable
+        SigInstanceVariableNode.new(raw_decl, lenv)
       else
         raise "unsupported: #{ raw_decl.class }"
       end

--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -434,6 +434,45 @@ module TypeProf::Core
       end
     end
 
+    class SigInstanceVariableNode < Node
+      def initialize(raw_decl, lenv)
+        super(raw_decl, lenv)
+        @var = raw_decl.name
+        @cpath = lenv.cref.cpath
+        @scope_level = lenv.cref.scope_level
+        @type = AST.create_rbs_type(raw_decl.type, lenv)
+      end
+
+      attr_reader :cpath, :scope_level, :type
+      def subnodes = { type: }
+      def attrs = { cpath: }
+
+      def define0(genv)
+        @type.define(genv)
+        mod = genv.resolve_ivar(cpath, scope_level == :class, @var)
+        mod.add_decl(self)
+        mod
+      end
+
+      def define_copy(genv)
+        mod = genv.resolve_ivar(cpath, scope_level == :class, @var)
+        mod.add_decl(self)
+        mod.remove_decl(@prev_node)
+        super(genv)
+      end
+
+      def undefine0(genv)
+        genv.resolve_ivar(cpath, scope_level == :class, @var).remove_decl(self)
+        @type.undefine(genv)
+      end
+
+      def install0(genv)
+        box = @changes.add_type_read_box(genv, @type)
+        @changes.add_edge(genv, box.ret, @static_ret.vtx)
+        box.ret
+      end
+    end
+
     class SigGlobalVariableNode < Node
       def initialize(raw_decl, lenv)
         super(raw_decl, lenv)

--- a/test/fixtures/rbs_collection_test/dummy_gem_source/my_dummy_gem/lib/my_dummy_gem.rb
+++ b/test/fixtures/rbs_collection_test/dummy_gem_source/my_dummy_gem/lib/my_dummy_gem.rb
@@ -1,4 +1,5 @@
 def hello(name)
-  "Hello, #{ name }"
+  @name = name
+  "Hello, #{ @name }"
   raise
 end

--- a/test/fixtures/rbs_collection_test/dummy_rbs_collection/my_dummy_gem/1.0/my_dummy_gem.rbs
+++ b/test/fixtures/rbs_collection_test/dummy_rbs_collection/my_dummy_gem/1.0/my_dummy_gem.rbs
@@ -1,3 +1,4 @@
 class MyDummyGem
+  @name: String
   def hello: (String) -> :ok
 end


### PR DESCRIPTION
When I was implementing TypeProf LSP plugin for coc.nvim, and I found the following this error.

```bash
'TypeProf::Core::AST.create_rbs_member': unsupported: RBS::AST::Members::InstanceVariable (RuntimeError)
```

Reading the code based on the error message, I found that an error occurs when instance variable written in RBS.

Therefore, I have added the `SigInstanceVariableNode` class that can be used in the case of `RBS::AST::Members::InstanceVariable` in `TypeProf::Core::AST.create_rbs_member` method.

However, I am not familiar with the internal code of TypeProf, so I would appreciate any comments if you have any better ways of writing it.