### PR TITLE
Remove eval workaround for keyword arguments in SigAttrReaderNode and SigAttrWriterNode

### DIFF
--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -280,17 +280,13 @@ module TypeProf::Core
       def initialize(raw_decl, lenv)
         super(raw_decl, lenv)
         @mid = raw_decl.name
-        # `eval` is used to prevent TypeProf from failing to parse keyword arguments during dogfooding.
-        # TODO: Remove `eval` once TypeProf supports keyword arguments.
-        eval <<~RUBY
-          rbs_method_type = RBS::MethodType.new(
-            type: RBS::Types::Function.empty(raw_decl.type),
-            type_params: [],
-            block: nil,
-            location: raw_decl.type.location,
-          )
-          @method_type = AST.create_rbs_func_type(rbs_method_type, [], nil, lenv)
-        RUBY
+        rbs_method_type = RBS::MethodType.new(
+          type: RBS::Types::Function.empty(raw_decl.type),
+          type_params: [],
+          block: nil,
+          location: raw_decl.type.location
+        )
+        @method_type = AST.create_rbs_func_type(rbs_method_type, [], nil, lenv)
       end
 
       attr_reader :mid, :method_type
@@ -309,27 +305,23 @@ module TypeProf::Core
         super(raw_decl, lenv)
         @mid = :"#{raw_decl.name}="
 
-        # `eval` is used to prevent TypeProf from failing to parse keyword arguments during dogfooding.
-        # TODO: Remove `eval` once TypeProf supports keyword arguments.
-        eval <<~RUBY
-          # (raw_decl.type) -> raw_decl.type
-          rbs_method_type = RBS::MethodType.new(
-            type: RBS::Types::Function.new(
-              required_positionals: [RBS::Types::Function::Param.new(name: nil, type: raw_decl.type, location: raw_decl.type.location)],
-              optional_positionals: [],
-              rest_positionals: nil,
-              trailing_positionals: [],
-              required_keywords: {},
-              optional_keywords: {},
-              rest_keywords: nil,
-              return_type: raw_decl.type,
-            ),
-            type_params: [],
-            block: nil,
-            location: raw_decl.type.location,
-          )
-          @method_type = AST.create_rbs_func_type(rbs_method_type, [], nil, lenv)
-        RUBY
+        # (raw_decl.type) -> raw_decl.type
+        rbs_method_type = RBS::MethodType.new(
+          type: RBS::Types::Function.new(
+            required_positionals: [RBS::Types::Function::Param.new(name: nil, type: raw_decl.type, location: raw_decl.type.location)],
+            optional_positionals: [],
+            rest_positionals: nil,
+            trailing_positionals: [],
+            required_keywords: {},
+            optional_keywords: {},
+            rest_keywords: nil,
+            return_type: raw_decl.type
+          ),
+          type_params: [],
+          block: nil,
+          location: raw_decl.type.location
+        )
+        @method_type = AST.create_rbs_func_type(rbs_method_type, [], nil, lenv)
       end
 
       attr_reader :mid, :method_type


### PR DESCRIPTION
This PR removes the `eval` workaround that was used to prevent TypeProf from failing to parse keyword arguments during dogfooding. Since TypeProf now supports keyword arguments, this workaround is no longer necessary.