### PR TITLE
Implement RBS Record type support

### DIFF
--- a/lib/typeprof/core/builtin.rb
+++ b/lib/typeprof/core/builtin.rb
@@ -90,10 +90,16 @@ module TypeProf::Core
     def hash_aref(changes, node, ty, a_args, ret)
       if a_args.positionals.size == 1
         case ty
-        when Type::Hash
+        when Type::Hash, Type::Record
           idx = node.positional_args[0]
           idx = idx.is_a?(AST::SymbolNode) ? idx.lit : nil
-          changes.add_edge(@genv, ty.get_value(idx), ret)
+          value = ty.get_value(idx)
+          if value
+            changes.add_edge(@genv, value, ret)
+          else
+            # Return untyped for unknown fields
+            changes.add_edge(@genv, Source.new(), ret)
+          end
           true
         else
           false

--- a/scenario/rbs/record-arrays.rb
+++ b/scenario/rbs/record-arrays.rb
@@ -1,0 +1,17 @@
+## update: test.rbs
+class RecordArrays
+  def get_users: -> Array[{ id: Integer, name: String }]
+end
+
+## update: test.rb
+class RecordArrays
+  def first_user
+    users = get_users
+    users.first
+  end
+end
+
+## assert: test.rb
+class RecordArrays
+  def first_user: -> { id: Integer, name: String }
+end

--- a/scenario/rbs/record-basic.rb
+++ b/scenario/rbs/record-basic.rb
@@ -1,0 +1,16 @@
+## update: test.rbs
+class BasicRecord
+  def simple_record: -> { name: String, age: Integer }
+end
+
+## update: test.rb
+class BasicRecord
+  def get_record
+    simple_record
+  end
+end
+
+## assert: test.rb
+class BasicRecord
+  def get_record: -> { name: String, age: Integer }
+end

--- a/scenario/rbs/record-empty.rb
+++ b/scenario/rbs/record-empty.rb
@@ -1,0 +1,16 @@
+## update: test.rbs
+class EmptyRecord
+  def empty_record: -> {  }
+end
+
+## update: test.rb
+class EmptyRecord
+  def get_empty
+    empty_record
+  end
+end
+
+## assert: test.rb
+class EmptyRecord
+  def get_empty: -> {  }
+end

--- a/scenario/rbs/record-field-access.rb
+++ b/scenario/rbs/record-field-access.rb
@@ -1,0 +1,17 @@
+## update: test.rbs
+class RecordFieldAccess
+  def get_person: -> { name: String, age: Integer }
+end
+
+## update: test.rb
+class RecordFieldAccess
+  def get_name
+    person = get_person
+    person[:name]
+  end
+end
+
+## assert: test.rb
+class RecordFieldAccess
+  def get_name: -> String
+end

--- a/scenario/rbs/record-field-error.rb
+++ b/scenario/rbs/record-field-error.rb
@@ -1,0 +1,17 @@
+## update: test.rbs
+class RecordFieldError
+  def get_person: -> { name: String, age: Integer }
+end
+
+## update: test.rb
+class RecordFieldError
+  def get_unknown_field
+    person = get_person
+    person[:unknown]  # Access non-existent field
+  end
+end
+
+## assert: test.rb
+class RecordFieldError
+  def get_unknown_field: -> untyped
+end

--- a/scenario/rbs/record-hash-compat.rb
+++ b/scenario/rbs/record-hash-compat.rb
@@ -1,0 +1,18 @@
+## update: test.rbs
+class RecordHashCompat
+  def get_symbol_hash: -> Hash[Symbol, String | Integer]
+  def accept_record: ({ name: String, age: Integer }) -> void
+end
+
+## update: test.rb
+class RecordHashCompat
+  def test_hash_to_record
+    hash_data = get_symbol_hash
+    accept_record(hash_data)
+  end
+end
+
+## assert: test.rb
+class RecordHashCompat
+  def test_hash_to_record: -> Object
+end

--- a/scenario/rbs/record-nested.rb
+++ b/scenario/rbs/record-nested.rb
@@ -1,0 +1,17 @@
+## update: test.rbs
+class NestedRecord
+  def get_company: -> { name: String, owner: { name: String, age: Integer } }
+end
+
+## update: test.rb
+class NestedRecord
+  def get_owner_name
+    company = get_company
+    company[:owner][:name]
+  end
+end
+
+## assert: test.rb
+class NestedRecord
+  def get_owner_name: -> String
+end

--- a/scenario/rbs/record-optional.rb
+++ b/scenario/rbs/record-optional.rb
@@ -1,0 +1,16 @@
+## update: test.rbs
+class OptionalRecord
+  def maybe_person: -> { name: String, age: Integer }?
+end
+
+## update: test.rb
+class OptionalRecord
+  def check_optional
+    maybe_person
+  end
+end
+
+## assert: test.rb
+class OptionalRecord
+  def check_optional: -> { name: String, age: Integer }?
+end

--- a/scenario/rbs/record-type-checking.rb
+++ b/scenario/rbs/record-type-checking.rb
@@ -1,0 +1,28 @@
+## update: test.rbs
+class RecordTypeChecking
+  def create_person: -> { name: String, age: Integer }
+  def accept_person: ({ name: String, age: Integer }) -> String
+  def process_user: ({ id: Integer, name: String, active: bool }) -> String
+end
+
+## update: test.rb
+class RecordTypeChecking
+  # Test case: Exact type matching
+  # Record type created by method matches the parameter type exactly
+  def test_exact_match
+    person = create_person
+    accept_person(person)
+  end
+
+  # Test case: Untyped parameter
+  # Parameter without type annotation is passed to method expecting Record type
+  def test_untyped_param(user_data)
+    process_user(user_data)
+  end
+end
+
+## assert: test.rb
+class RecordTypeChecking
+  def test_exact_match: -> String
+  def test_untyped_param: (untyped) -> String
+end


### PR DESCRIPTION
Add comprehensive support for RBS Record types ({ key: Type }) in TypeProf with field access, type checking, and error handling capabilities.

## Core Implementation

* **SigTyRecordNode**: Parse and process Record type definitions from RBS
* **Record class**: New type class with field access and matching support
* **Hash integration**: Shared builtin support for Hash and Record types
* **Type compatibility**: Enable Hash-Record interoperability in method calls

## Features

* Field access via [] operator (e.g., record[:name] -> String)
* Proper type checking for Record parameters and return values
* Union type support for Record field values
* Graceful error handling for non-existent field access (returns untyped)
* Hash[Symbol, T] to Record type compatibility

## Test Coverage

Added 9 comprehensive test files covering:
- Basic Record type usage and type propagation
- Field access and nested Record structures
- Hash-Record type compatibility scenarios
- Error handling for invalid field access
- Optional Record types and empty Records
- Array integration with Record types

## Technical Details

Record types are internally represented with a base Hash type to maintain compatibility with Ruby's hash-like access patterns. Field values are properly unified into a union type for the underlying Hash value type.

🤖 Generated with [Claude Code](https://claude.ai/code)