### PR TITLE
Only load what is required from cgi

### DIFF
--- a/lib/typeprof/lsp/server.rb
+++ b/lib/typeprof/lsp/server.rb
@@ -1,4 +1,5 @@
-require "cgi"
+require "cgi/escape"
+require "cgi/util" if RUBY_VERSION < "3.5"
 
 module TypeProf::LSP
   module ErrorCodes


### PR DESCRIPTION
In Ruby 3.5 most of the `cgi` gem will be removed. Only the various escape/unescape methods will be retained by default.

On older versions, `require "cgi/util"` is needed because the unescape* methods don't work otherwise.

https://bugs.ruby-lang.org/issues/21258