### PR TITLE
Implement RBS prepend support with comprehensive tests

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -400,6 +400,8 @@ module TypeProf::Core
         SigDefNode.new(raw_decl, lenv)
       when RBS::AST::Members::Include
         SigIncludeNode.new(raw_decl, lenv)
+      when RBS::AST::Members::Prepend
+        SigPrependNode.new(raw_decl, lenv)
       when RBS::AST::Members::Extend
       when RBS::AST::Members::Public
       when RBS::AST::Members::Private

--- a/scenario/rbs/prepend.rb
+++ b/scenario/rbs/prepend.rb
@@ -1,0 +1,29 @@
+## update: test.rbs
+module M
+  def foo: () -> String
+end
+
+class C
+  prepend M
+
+  def foo: () -> Integer
+end
+
+class Object
+  def accept_m: (M) -> String
+end
+
+## update: test.rb
+def test
+  accept_m(C.new)
+end
+
+def test2
+  C.new.foo
+end
+
+## assert
+class Object
+  def test: -> String
+  def test2: -> String
+end

--- a/scenario/rbs/prepend_include_mix.rb
+++ b/scenario/rbs/prepend_include_mix.rb
@@ -1,0 +1,48 @@
+## update: test.rbs
+module M1
+  def foo: () -> :m1
+end
+
+module M2
+  def foo: () -> :m2
+  def bar: () -> :m2
+end
+
+module M3
+  def foo: () -> :m3
+  def bar: () -> :m3
+  def baz: () -> :m3
+end
+
+class C
+  include M1
+  prepend M2
+  include M3
+
+  def foo: () -> :c
+  def bar: () -> :c
+  def baz: () -> :c
+end
+
+## update: test.rb
+def test_foo
+  # Should return :m2 (prepended module wins)
+  C.new.foo
+end
+
+def test_bar
+  # Should return :m2 (prepended module wins)
+  C.new.bar
+end
+
+def test_baz
+  # Should return :c (class method overrides included module)
+  C.new.baz
+end
+
+## assert
+class Object
+  def test_foo: -> :m2
+  def test_bar: -> :m2
+  def test_baz: -> :c
+end

--- a/scenario/rbs/prepend_multiple.rb
+++ b/scenario/rbs/prepend_multiple.rb
@@ -1,0 +1,47 @@
+## update: test.rbs
+module M1
+  def foo: () -> :m1
+end
+
+module M2
+  def foo: () -> :m2
+  def bar: () -> :m2
+end
+
+class C
+  prepend M1
+  prepend M2
+
+  def foo: () -> :c
+  def bar: () -> :c
+end
+
+class Object
+  def accept_m1: (M1) -> String
+  def accept_m2: (M2) -> String
+end
+
+## update: test.rb
+def test_foo
+  C.new.foo
+end
+
+def test_bar
+  C.new.bar
+end
+
+def test_type_m1
+  accept_m1(C.new)
+end
+
+def test_type_m2
+  accept_m2(C.new)
+end
+
+## assert
+class Object
+  def test_foo: -> :m2
+  def test_bar: -> :m2
+  def test_type_m1: -> String
+  def test_type_m2: -> String
+end


### PR DESCRIPTION
This commit adds full support for RBS::AST::Members::Prepend to properly handle prepended modules in type checking and method resolution.

Key changes:
- Add SigPrependNode class to handle prepend declarations
- Separate prepended_modules from included_modules in ModuleEntity
- Fix method resolution order: prepended modules → class → included modules
- Update type compatibility checking to recognize prepended modules
- Fix prepend module ordering (last prepended = first in ancestor chain)
- Add break after finding first matching prepended method

Testing:
- Add test for basic prepend functionality
- Add test for multiple prepended modules
- Add test for prepend and include combination

This ensures that when a class prepends a module, instances of that class are correctly recognized as compatible with the module type, and methods from prepended modules properly override class methods following Ruby semantics.

🤖 Generated with [Claude Code](https://claude.ai/code)