### PR TITLE
Fix unknown type variable error in generic RBS class definitions

### DIFF
--- a/scenario/rbs/param8.rb
+++ b/scenario/rbs/param8.rb
@@ -1,0 +1,4 @@
+## update: test.rbs
+class Foo[X]
+  @x: X
+end


### PR DESCRIPTION
Resolves the "unknown type variable: X" error that occurred when processing instance variables using type parameters within generic RBS class definitions like `class Foo[X]` with `@x: X`.

The fix creates proper type parameter substitution maps for SigInstanceVariableNode contexts, allowing type variables to be correctly resolved within generic classes.

🤖 Generated with [Claude Code](https://claude.ai/code)