### PR TITLE
Fix stack overflow error in recursive type alias expansion

### DIFF
--- a/scenario/rbs/recursive-type-alias.rb
+++ b/scenario/rbs/recursive-type-alias.rb
@@ -1,0 +1,79 @@
+## update: test.rbs
+# Basic recursive type alias
+type context = nil | [context, bool]
+
+class C
+  def foo: -> context
+end
+
+## update: test.rb
+def test1
+  C.new.foo
+end
+
+## assert: test.rb
+class Object
+  def test1: -> [untyped, bool]?
+end
+
+## diagnostics: test.rb
+
+## update: test.rbs
+# Recursive type alias in class scope
+class D
+  type tree = Integer | [tree, tree]
+  def get_tree: -> tree
+end
+
+## update: test.rb
+def test2
+  D.new.get_tree
+end
+
+## assert: test.rb
+class Object
+  def test2: -> (Integer | [untyped, untyped])
+end
+
+## diagnostics: test.rb
+
+## update: test.rbs
+# Mutually recursive type aliases
+type node = [Integer, nodes]
+type nodes = Array[node]
+
+class E
+  def build_tree: -> node
+end
+
+## update: test.rb
+def test3
+  E.new.build_tree
+end
+
+## assert: test.rb
+class Object
+  def test3: -> [Integer, Array[untyped]]
+end
+
+## diagnostics: test.rb
+
+## update: test.rbs
+# Recursive type alias with generic parameters
+type list[T] = nil | [T, list[T]]
+
+class F
+  def create_list: -> list[String]
+end
+
+## update: test.rb
+def test4
+  F.new.create_list
+end
+
+## assert: test.rb
+class Object
+  def test4: -> [String, untyped]?
+end
+
+## diagnostics: test.rb


### PR DESCRIPTION
This commit fixes issue #324 where recursive type aliases caused SystemStackError due to infinite recursion during type expansion.

The fix adds recursion detection in SigTyAliasNode#covariant_vertex0 and #contravariant_vertex0 methods by tracking the expansion stack using subst[:__expansion_stack__]. When a type alias is already being expanded, the expansion stops to prevent infinite recursion.

Also adds comprehensive test cases for various recursive type alias patterns including direct recursion, mutual recursion, and generic recursive types.

Fixes #324

🤖 Generated with [Claude Code](https://claude.ai/code)