### PR TITLE
Fix NotImplementedError in SigTyProcNode for RBS proc types

### DIFF
--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -628,16 +628,39 @@ module TypeProf::Core
     end
 
     class SigTyProcNode < SigTyNode
+      def initialize(raw_decl, lenv)
+        super(raw_decl, lenv)
+        # raw_decl.type is an RBS::Types::Function, we need to wrap it in a MethodType
+        if raw_decl.type
+          method_type = RBS::MethodType.new(
+            type: raw_decl.type,
+            type_params: [],
+            block: raw_decl.block,
+            location: raw_decl.location
+          )
+          @type = AST.create_rbs_func_type(method_type, nil, raw_decl.block, lenv)
+        else
+          @type = nil
+        end
+      end
+
+      attr_reader :type
+      def subnodes = { type: }
+
       def covariant_vertex0(genv, changes, vtx, subst)
-        raise NotImplementedError
+        # For now, just return the base Proc type without the function signature details
+        # TODO: Create a proper Type::Proc with the function signature
+        changes.add_edge(genv, Source.new(genv.proc_type), vtx)
       end
 
       def contravariant_vertex0(genv, changes, vtx, subst)
-        Source.new()
+        # For now, just return the base Proc type without the function signature details
+        # TODO: Create a proper Type::Proc with the function signature
+        changes.add_edge(genv, Source.new(genv.proc_type), vtx)
       end
 
       def show
-        "(...proc...)"
+        "^(...)"
       end
     end
 

--- a/scenario/rbs/proc.rb
+++ b/scenario/rbs/proc.rb
@@ -1,0 +1,73 @@
+## update: test.rbs
+class Foo
+  @proc: ^() -> Integer
+
+  def set_proc: (^(String) -> Integer) -> void
+  def get_proc: () -> ^() -> String
+end
+
+## update: test.rb
+class Foo
+  def initialize
+    @proc = -> { 42 }
+  end
+
+  def set_proc(p)
+    @proc = p
+  end
+
+  def get_proc
+    -> { "hello" }
+  end
+end
+
+## assert
+class Foo
+  def initialize: -> Proc
+  def set_proc: (Proc) -> Proc
+  def get_proc: -> Proc
+end
+
+## update: test.rbs
+class Object
+  def take_proc: (^(Integer) -> String) -> void
+  def call_proc: (^() -> Integer) -> Integer
+end
+
+## update: test.rb
+def take_proc(p)
+  p.call(42)
+end
+
+def call_proc(p)
+  p.call
+end
+
+## assert
+class Object
+  def take_proc: (Proc) -> untyped
+  def call_proc: (Proc) -> untyped
+end
+
+## update: test.rbs
+class Bar
+  def with_block: () { () -> Integer } -> void
+  def proc_arg: (^(String) -> Integer) -> Integer
+end
+
+## update: test.rb
+class Bar
+  def with_block(&block)
+    block.call
+  end
+
+  def proc_arg(p)
+    p.call("test")
+  end
+end
+
+## assert
+class Bar
+  def with_block: { () -> untyped } -> untyped
+  def proc_arg: (Proc) -> untyped
+end


### PR DESCRIPTION
Previously, using proc types in RBS files (e.g., ^() -> Integer) would raise NotImplementedError when TypeProf tried to process them through SigTyProcNode#covariant_vertex0.

This commit:
- Adds initialize method to SigTyProcNode to properly parse RBS::Types::Proc
- Implements covariant_vertex0 and contravariant_vertex0 methods
- Wraps RBS::Types::Function in RBS::MethodType for compatibility
- Adds comprehensive test scenarios for proc type handling

The implementation currently returns the base Proc type without detailed function signature information, which can be enhanced in the future.

🤖 Generated with Claude Code