### PR TITLE
Support anonymous rest and keyword argument forwarding

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -35,7 +35,7 @@ module TypeProf::Core
               @splat_flags << false
             end
           end
-          @positional_args = args.map {|arg| AST.create_node(arg, lenv) }
+          @positional_args = args.map {|arg| arg ? AST.create_node(arg, lenv) : DummyNilNode.new(code_range, lenv) }
 
           if @positional_args.last.is_a?(TypeProf::Core::AST::HashNode) && @positional_args.last.keywords
             @keyword_args = @positional_args.pop
@@ -93,7 +93,11 @@ module TypeProf::Core
         end
 
         positional_args = @positional_args.map do |arg|
-          arg.install(genv)
+          if arg.is_a?(DummyNilNode)
+            @lenv.get_var(:"*anonymous_rest")
+          else
+            arg.install(genv)
+          end
         end
 
         keyword_args = @keyword_args ? @keyword_args.install(genv) : nil

--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -272,7 +272,11 @@ module TypeProf::Core
             @vals << AST.create_node(raw_elem.value, lenv)
           when :assoc_splat_node
             @keys << nil
-            @vals << AST.create_node(raw_elem.value, lenv)
+            if raw_elem.value
+              @vals << AST.create_node(raw_elem.value, lenv)
+            else
+              @vals << DummyNilNode.new(code_range, lenv)
+            end
             @splat = true
           else
             raise "unknown hash elem: #{ raw_elem.type }"
@@ -297,7 +301,11 @@ module TypeProf::Core
             @changes.add_edge(genv, v, unified_val)
             literal_pairs[key.lit] = v if key.is_a?(SymbolNode)
           else
-            h = val.install(genv)
+            if val.is_a?(DummyNilNode)
+              h = @lenv.get_var(:"**anonymous_keyword")
+            else
+              h = val.install(genv)
+            end
             # TODO: do we want to call to_hash on h?
             @changes.add_hash_splat_box(genv, h, unified_key, unified_val)
           end

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -627,7 +627,7 @@ module TypeProf::Core
         end
       end
       if @f_args.rest_keywords
-        args << "**#{ Type.strip_parens(@f_args.rest_keywords.show) }"
+        args << "**#{ Type.extract_hash_value_type(Type.strip_parens(@f_args.rest_keywords.show)) }"
       end
 
       if output_parameter_names && @node.is_a?(AST::DefNode)

--- a/lib/typeprof/core/type.rb
+++ b/lib/typeprof/core/type.rb
@@ -15,6 +15,20 @@ module TypeProf::Core
       s.start_with?("Array[") && s.end_with?("]") ? s[6..-2] || raise : s
     end
 
+    def self.extract_hash_value_type(s)
+      if s.start_with?("Hash[") && s.end_with?("]")
+        type = RBS::Parser.parse_type(s)
+
+        if type.is_a?(RBS::Types::Union)
+          type.types.map {|t| t.args[1].to_s }.join(" | ")
+        else
+          type.args[1].to_s
+        end
+      else
+        s
+      end
+    end
+
     def self.default_param_map(genv, ty)
       ty = ty.base_type(genv)
       instance_ty = ty.is_a?(Type::Instance) ? ty : Type::Instance.new(genv, ty.mod, []) # TODO: type params

--- a/scenario/args/anonymous_keyword.rb
+++ b/scenario/args/anonymous_keyword.rb
@@ -1,0 +1,16 @@
+## update
+def foo(**)
+  bar(**)
+end
+
+def bar(**)
+  nil
+end
+
+bar(x: 1, y: "foo")
+
+## assert
+class Object
+  def foo: (**untyped) -> nil
+  def bar: (**Integer | String | untyped) -> nil
+end

--- a/scenario/args/anonymous_rest.rb
+++ b/scenario/args/anonymous_rest.rb
@@ -1,0 +1,16 @@
+## update
+def foo(*)
+  bar(*)
+end
+
+def bar(*)
+  nil
+end
+
+bar(1, "foo")
+
+## assert
+class Object
+  def foo: (*untyped) -> nil
+  def bar: (*Integer | String) -> nil
+end

--- a/scenario/method/keywords.rb
+++ b/scenario/method/keywords.rb
@@ -71,5 +71,5 @@ foo(a: '', b: 1, c: true)
 
 ## assert
 class Object
-  def foo: (a: String, ?b: Integer, **Hash[:a | :b | :c, Integer | String | true]) -> Hash[:a | :b | :c, Integer | String | true]
+  def foo: (a: String, ?b: Integer, **Integer | String | true) -> Hash[:a | :b | :c, Integer | String | true]
 end


### PR DESCRIPTION
- Fix NoMethodError when using anonymous rest (*) and keyword (**) forwarding
- Extract Hash value types for RBS keyword parameters (Hash[K, V] → V)
- Add proper type inference for anonymous argument scenarios

This enables method calls like foo(*) and foo(**) to work correctly and ensures RBS output shows the actual value types for keyword parameters rather than the full Hash type.