### PR TITLE
Fix NoMethodError in SigTyIntersectionNode when using intersection types

### DIFF
--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -491,12 +491,25 @@ module TypeProf::Core
     end
 
     class SigTyIntersectionNode < SigTyNode
+      def initialize(raw_decl, lenv)
+        super(raw_decl, lenv)
+        @types = (raw_decl.types || []).map {|type| AST.create_rbs_type(type, lenv) }
+      end
+
+      attr_reader :types
+
+      def subnodes = { types: }
+
       def covariant_vertex0(genv, changes, vtx, subst)
-        #raise NotImplementedError
+        @types.each do |type|
+          type.covariant_vertex0(genv, changes, vtx, subst)
+        end
       end
 
       def contravariant_vertex0(genv, changes, vtx, subst)
-        #raise NotImplementedError
+        @types.each do |type|
+          type.contravariant_vertex0(genv, changes, vtx, subst)
+        end
       end
 
       def typecheck(genv, changes, vtx, subst)
@@ -507,7 +520,7 @@ module TypeProf::Core
       end
 
       def show
-        "(...intersection...)"
+        @types.map {|ty| ty.show }.join(" & ")
       end
     end
 

--- a/scenario/rbs/intersection.rb
+++ b/scenario/rbs/intersection.rb
@@ -1,0 +1,39 @@
+## update: test.rbs
+interface _Readable
+  def read: () -> String
+end
+
+interface _Writable
+  def write: (String) -> void
+end
+
+class Processor
+  def process: (_Readable & _Writable) -> String
+end
+
+## update: test.rb
+class MyIO
+  def read
+    "content"
+  end
+
+  def write(text)
+    text
+  end
+end
+
+class Processor
+  def process_file
+    io = MyIO.new
+    process(io)
+  end
+end
+
+## assert: test.rb
+class MyIO
+  def read: -> String
+  def write: (untyped) -> untyped
+end
+class Processor
+  def process_file: -> String
+end


### PR DESCRIPTION
When I tried TypeProf in VSCode, I got the following error:

```
/Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/ast/sig_type.rb:503:in `typecheck': undefined method `each' for nil (NoMethodError)

        @types.each do |type|
              ^^^^^
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/graph/box.rb:152:in `block in match_arguments?'
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/graph/box.rb:151:in `each'
```

This is because the SigTyIntersectionNode class does not have an initialize method, and the `@types` instance is not initialized.
This commit fixes it.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>