### PR TITLE
Fix NoMethodError in `SigTyTupleNode#typecheck` for instance types

### DIFF
--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -711,7 +711,7 @@ module TypeProf::Core
             return true
           when Type::Instance
             @types.each do |f_ty|
-              return false unless f_ty.typecheck(genv, changes, ty, subst)
+              return false unless f_ty.typecheck(genv, changes, vtx, subst)
             end
             return true
           end


### PR DESCRIPTION
`SigTyTupleNode#typecheck` was passing wrong parameter (ty instead of vtx)
to `f_ty.typecheck` when handling `Type::Instance` objects, causing:
"undefined method `each_type' for an instance of TypeProf::Core::Type::Instance".

```
/Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/ast/sig_type.rb:5:in `typecheck_for_module': undefined method `each_type' for an instance of TypeProf::Core::Type::Instance (NoMethodError)

      a_vtx.each_type do |ty|
           ^^^^^^^^^^
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/ast/sig_type.rb:669:in `typecheck'
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/ast/sig_type.rb:727:in `block (2 levels) in typecheck'
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/ast/sig_type.rb:726:in `each'
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/ast/sig_type.rb:726:in `block in typecheck'
```
