### PR TITLE
Fix infinite loop caused by inline RBS comments

### DIFF
--- a/lib/typeprof/core/graph/change_set.rb
+++ b/lib/typeprof/core/graph/change_set.rb
@@ -22,7 +22,7 @@ module TypeProf::Core
       @new_depended_superclasses = []
     end
 
-    attr_reader :node, :target, :covariant_types, :edges, :boxes, :diagnostics
+    attr_reader :node, :target, :covariant_types, :contravariant_types, :edges, :boxes, :diagnostics
 
     def reuse(new_node)
       @node = new_node
@@ -33,11 +33,13 @@ module TypeProf::Core
 
     def copy_from(other)
       @covariant_types = other.covariant_types.dup
+      @contravariant_types = other.contravariant_types.dup
       @edges = other.edges.dup
       @boxes = other.boxes.dup
       @diagnostics = other.diagnostics.dup
 
       other.covariant_types.clear
+      other.contravariant_types.clear
       other.edges.clear
       other.boxes.clear
       other.diagnostics.clear
@@ -55,7 +57,8 @@ module TypeProf::Core
     end
 
     def new_contravariant_vertex(genv, sig_type_node)
-      Vertex.new(sig_type_node)
+      # This is used to avoid duplicated vertex generation for the same sig node
+      @contravariant_types[sig_type_node] ||= Vertex.new(sig_type_node)
     end
 
     def add_edge(genv, src, dst)

--- a/scenario/rbs/inline2.rb
+++ b/scenario/rbs/inline2.rb
@@ -1,0 +1,12 @@
+## update
+class C
+  #: (Array[untyped]) -> Array[untyped]
+  def foo(x)
+    x
+  end
+end
+
+## assert
+class C
+  def foo: (Array[untyped]) -> Array[untyped]
+end


### PR DESCRIPTION
When analyzing the following code with TypeProf, an infinite loop occurs.

```ruby
class C
  #: (Array[untyped]) -> Array[untyped]
  def foo(x)
    x
  end
end
```

TypeProf generates duplicate vertices for the same sig node.
To resolve this issue, it restores the code removed in 3251cbc362112381f5e84f51ba6f82c64dc170ac.

---

I'm not sure if restoring this code is correct.
However, all tests now pass, so I created a PR.