### PR TITLE
Output the file path when an error occurs during analysis

### DIFF
--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -511,6 +511,9 @@ module TypeProf::Core
           output.puts "# failed to analyze: #{ file }"
           false
         end
+      rescue => e
+        output.puts "# error: #{ file }"
+        raise e
       end
       if @options[:display_indicator]
         $stderr << "\r\e[K"

--- a/test/core/service_test.rb
+++ b/test/core/service_test.rb
@@ -1,0 +1,25 @@
+require_relative "../helper"
+require "stringio"
+require "tempfile"
+
+module TypeProf::Core
+  class ServiceTest < Test::Unit::TestCase
+    def test_runtime_error
+      options = {}
+      service = TypeProf::Core::Service.new(options)
+
+      # Mocking an error while analyzing a file
+      service.extend(Module.new do
+        def update_rb_file(*)
+          raise
+        end
+      end)
+
+      Tempfile.create(["", ".rb"]) do |f|
+        output = StringIO.new(+"")
+        assert_raises(RuntimeError) { service.batch([f.path], output) }
+        assert_equal("# error: #{f.path}\n", output.string)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add error handling to output the path of the file being analyzed when an
exception occurs, making it easier to identify which file caused the error.
