### PR TITLE
Fix RuntimeError when using multiple hash splat operators

### DIFF
--- a/lib/typeprof/core/graph/vertex.rb
+++ b/lib/typeprof/core/graph/vertex.rb
@@ -188,12 +188,14 @@ module TypeProf::Core
     end
 
     def add_edge(genv, nvtx)
+      return if @next_vtxs.include?(nvtx)
       @next_vtxs << nvtx
       nvtx.on_type_added(genv, self, @types.keys) unless @types.empty?
     end
 
     def remove_edge(genv, nvtx)
-      @next_vtxs.delete(nvtx) || raise
+      return unless @next_vtxs.include?(nvtx)
+      @next_vtxs.delete(nvtx)
       nvtx.on_type_removed(genv, self, @types.keys) unless @types.empty?
     end
 

--- a/scenario/regressions/hash-with-splat-operator.rb
+++ b/scenario/regressions/hash-with-splat-operator.rb
@@ -1,0 +1,11 @@
+## update
+def opts(prefix)
+  { "#{prefix}_key" => 1 }
+end
+
+def test
+  {
+    **opts(:cat),
+    **opts(:dog)
+  }
+end


### PR DESCRIPTION
When multiple hash splat operators expand hashes of the same type,
duplicate edges were being added to the same vertex, causing `Set#<<`
to raise an error. Modified `Vertex#add_edge` and `Vertex#remove_edge`
to handle duplicate edges gracefully.
