### PR TITLE
Fix RuntimeError when using multiple hash splat operators

### DIFF
--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -380,8 +380,8 @@ module TypeProf::Core
       @hsh.each_type do |ty|
         ty = ty.base_type(genv)
         if ty.mod == genv.mod_hash
-          changes.add_edge(genv, ty.args[0], @unified_key)
-          changes.add_edge(genv, ty.args[1], @unified_val)
+          changes.add_edge(genv, ty.args[0].new_vertex(genv, :__hash_splat), @unified_key)
+          changes.add_edge(genv, ty.args[1].new_vertex(genv, :__hash_splat), @unified_val)
         else
           "???"
         end

--- a/scenario/regressions/hash-with-splat-operator.rb
+++ b/scenario/regressions/hash-with-splat-operator.rb
@@ -1,0 +1,11 @@
+## update
+def opts(prefix)
+  { "#{prefix}_key" => 1 }
+end
+
+def test
+  {
+    **opts(:cat),
+    **opts(:dog)
+  }
+end


### PR DESCRIPTION
When multiple hash splat operators expand hashes of the same type, duplicate edges were being added to the same vertex, causing `Set#<<` to raise an error. This can be avoided by using `Vertex#new_vertex`.

This fixes #343.