### PR TITLE
Fix error by auto-detecting `analysis_unit_dirs`

### DIFF
--- a/lib/typeprof/cli/cli.rb
+++ b/lib/typeprof/cli/cli.rb
@@ -184,7 +184,15 @@ module TypeProf::CLI
     end
 
     def generate_config_file
-      File.write('typeprof.conf.jsonc', File.read(File.join(__dir__, 'typeprof.conf.jsonc')), mode: "wx")
+      exist_dirs = ["app", "lib"].select { |dir| File.exist?(File.join(Dir.pwd, dir)) }
+      File.write('typeprof.conf.jsonc', <<~JSONC, mode: "wx")
+        {
+          "typeprof_version": "experimental",
+          "rbs_dir": "sig/",
+          "analysis_unit_dirs": #{exist_dirs.inspect}
+          // "diagnostic_severity": "warning"
+        }
+      JSONC
     end
   end
 end

--- a/lib/typeprof/cli/typeprof.conf.jsonc
+++ b/lib/typeprof/cli/typeprof.conf.jsonc
@@ -1,6 +1,0 @@
-{
-  "typeprof_version": "experimental",
-  "rbs_dir": "sig/"
-  // "analysis_unit_dirs": [],
-  // "diagnostic_severity": "warning"
-}


### PR DESCRIPTION
The LSP server requires `conf[:analysis_unit_dirs]` at server.rb:107,
causing errors when the config field is missing. Auto-detect "app"
and "lib" directories to populate this field in generated configs.

fixes #323