### PR TITLE
Add the `typeprof.enableToggleButton` notification

### DIFF
--- a/lib/typeprof/lsp/messages.rb
+++ b/lib/typeprof/lsp/messages.rb
@@ -137,6 +137,7 @@ module TypeProf::LSP
       text = Text.new(path, text, version)
       @server.open_texts[uri] = text
       @server.update_file(text.path, text.string)
+      notify("typeprof.enableToggleButton")
       @server.send_request("workspace/codeLens/refresh")
       @server.publish_updated_diagnostics
     end

--- a/test/lsp/lsp_test.rb
+++ b/test/lsp/lsp_test.rb
@@ -94,6 +94,7 @@ foo(1)
         END
       )
 
+      expect_notification("typeprof.enableToggleButton") {|json| }
       expect_request("workspace/codeLens/refresh") {|json| }
 
       notify(
@@ -116,6 +117,7 @@ foo(1)
         END
       )
 
+      expect_notification("typeprof.enableToggleButton") {|json| }
       expect_request("workspace/codeLens/refresh") {|json| }
 
       id = request(
@@ -165,6 +167,7 @@ foo(1, 2)
         END
       )
 
+      expect_notification("typeprof.enableToggleButton") {|json| }
       expect_request("workspace/codeLens/refresh") {|json| }
       expect_notification("textDocument/publishDiagnostics") do |json|
         assert_equal({
@@ -195,6 +198,7 @@ def check(nnn)
 end
         END
       )
+      expect_notification("typeprof.enableToggleButton") {|json| }
       expect_request("workspace/codeLens/refresh") {|json| }
 
       notify(
@@ -204,6 +208,7 @@ check(1, 2)
         END
       )
 
+      expect_notification("typeprof.enableToggleButton") {|json| }
       expect_request("workspace/codeLens/refresh") {|json| }
       expect_notification("textDocument/publishDiagnostics") do |json|
         assert_equal({
@@ -263,6 +268,7 @@ test(Foo.new)
         END
       )
 
+      expect_notification("typeprof.enableToggleButton") {|json| }
       expect_request("workspace/codeLens/refresh") {|json| }
 
       id = request(


### PR DESCRIPTION
The toggle button is not displayed in vscode-typeprof because there is
no `typeprof.enableToggleButton` notification.
refs: https://github.com/ruby/vscode-typeprof/blob/7431f0ea6775e5013fb47bc96b74ad5d4d91584a/src/extension.ts#L287-L289

This notification was in v0.21.11 but is no longer there.
refs: https://github.com/ruby/typeprof/blob/v0.21.11/lib/typeprof/lsp.rb#L355

Add a notification to display the toggle button.
