### PR TITLE
Move Prism dependency to gemspec file from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
+gemspec
 
 #if ENV["RBS_VERSION"]
   gem "rbs", github: "ruby/rbs", ref: ENV["RBS_VERSION"]
@@ -6,8 +7,6 @@ source "https://rubygems.org"
 #  # Specify your gem's dependencies in typeprof.gemspec
 #  gemspec
 #end
-
-gem "prism", ">= 1.4.0"
 
 group :development do
   gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,38 @@
 GIT
   remote: https://github.com/ruby/rbs.git
-  revision: bcc737da3c8c625d55d9b8856d9b8399b92a32d4
+  revision: d86ab02eb7e41343b8391bc38e349b40c7e72b15
   specs:
-    rbs (3.5.1)
+    rbs (4.0.0.dev.4)
       logger
+      prism (>= 1.3.0)
+      tsort
+
+PATH
+  remote: .
+  specs:
+    typeprof (0.30.1)
+      prism (>= 1.4.0)
+      rbs (>= 3.6.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coverage-helpers (1.0.0)
-    docile (1.4.0)
-    logger (1.6.0)
-    power_assert (2.0.3)
-    prism (1.4.0)
-    rake (13.2.1)
+    docile (1.4.1)
+    logger (1.7.0)
+    power_assert (3.0.0)
+    prism (1.6.0)
+    rake (13.3.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-html (0.12.3)
+    simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    stackprof (0.2.26)
-    test-unit (3.6.2)
+    stackprof (0.2.27)
+    test-unit (3.7.1)
       power_assert
+    tsort (0.2.0)
 
 PLATFORMS
   ruby
@@ -30,13 +40,13 @@ PLATFORMS
 
 DEPENDENCIES
   coverage-helpers
-  prism (>= 1.4.0)
   rake
   rbs!
   simplecov
   simplecov-html
   stackprof
   test-unit
+  typeprof!
 
 BUNDLED WITH
-   2.6.8
+   2.6.9

--- a/typeprof.gemspec
+++ b/typeprof.gemspec
@@ -28,5 +28,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "prism", ">= 1.4.0"
   spec.add_runtime_dependency "rbs", ">= 3.6.0"
 end


### PR DESCRIPTION
* typeprof.gemspec:, Gemfile, Gemfile.lock: Using TypeProf as a library does not resolve Gemfile dependencies, so move Prism to gemspec file.  Notice that TypeProf now uses Prism version 1.4.0 or later[1].

[1] Update Prism to 1.4.0 and remove workarounds,
    https://github.com/ruby/typeprof/pull/312