### PR TITLE
Update TypeProf version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    typeprof (0.30.1)
+    typeprof (0.31.0)
       prism (>= 1.4.0)
       rbs (>= 3.6.0)
 


### PR DESCRIPTION
TypeProf was recently updated to v0.31.0, causing version mismatches in Gemfile.lock on every bundle install.