### PR TITLE
Fix type inference for Class.new assigned to constants

### DIFF
--- a/scenario/control/rescue-assign-with-class-new.rb
+++ b/scenario/control/rescue-assign-with-class-new.rb
@@ -1,0 +1,15 @@
+## update: my_error.rb
+MyError = Class.new(StandardError)
+
+## update: test.rb
+class C
+  def foo
+  rescue MyError => e
+    raise ArgumentError, e.message
+  end
+end
+
+## assert: test.rb
+class C
+  def foo: -> nil
+end


### PR DESCRIPTION
When a constant is assigned the result of Class.new (e.g.,
MyError = Class.new(StandardError)), TypeProf now correctly infers
the constant as a singleton type instead of a Class instance.

This fixes a NoMethodError when using such dynamically created
classes in rescue clauses with assignment (rescue MyError => e).

Changes:
- Detect Class.new pattern in ConstantWriteNode#install0
- Create singleton type for the constant when Class.new is detected
- Support both Class.new and ::Class.new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
