### PR TITLE
Fix crash when rescuing non-class constants

### DIFF
--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -1099,7 +1099,7 @@ module TypeProf::Core
     def run0(genv, changes)
       instance_tys = []
       @singleton_ty_vtx.each_type do |ty|
-        instance_tys << ty.get_instance_type(genv)
+        instance_tys << ty.get_instance_type(genv) if ty.is_a?(Type::Singleton)
       end
       source_vtx = Source.new(*instance_tys)
       changes.add_edge(genv, source_vtx, @ret)

--- a/scenario/control/rescue-assign-with-class-new.rb
+++ b/scenario/control/rescue-assign-with-class-new.rb
@@ -1,0 +1,15 @@
+## update: my_error.rb
+MyError = Class.new(StandardError)
+
+## update: test.rb
+class C
+  def foo
+  rescue MyError => e
+    raise ArgumentError, e.message
+  end
+end
+
+## assert: test.rb
+class C
+  def foo: -> nil
+end

--- a/scenario/control/rescue-assign-with-non-singleton.rb
+++ b/scenario/control/rescue-assign-with-non-singleton.rb
@@ -1,0 +1,16 @@
+## update
+NonException = :foo
+
+def foo(n)
+  1
+rescue NonException => e
+  e
+end
+
+## diagnostics
+
+## assert
+NonException: :foo
+class Object
+  def foo: (untyped) -> Integer
+end


### PR DESCRIPTION
Previously, TypeProf would crash when encountering `rescue X => e` if `X` was a non-class constant (e.g., `X = 1`).

This commit fixes the issue by handling cases where the rescued object is not a singleton type, preventing the unhandled exception during type inference.

Fixes #351