### PR TITLE
Add support for nested multi-target nodes in destructuring assignment

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -270,6 +270,8 @@ module TypeProf::Core
         IndexWriteNode.new(raw_node, dummy_node, lenv)
       when :call_target_node
         CallWriteNode.new(raw_node, dummy_node, lenv)
+      when :multi_target_node
+        MultiTargetNode.new(raw_node, dummy_node, lenv)
       else
         pp raw_node
         raise "not supported yet: #{ raw_node.type }"

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -1073,7 +1073,7 @@ module TypeProf::Core
         else
           if @lefts.size >= 1
             edges << [Source.new(ty), @lefts[0]]
-          elsif @rights.size >= 1
+          elsif @rights && @rights.size >= 1
             edges << [Source.new(ty), @rights[0]]
           else
             edges << [Source.new(ty), @rest_elem]

--- a/lib/typeprof/core/type.rb
+++ b/lib/typeprof/core/type.rb
@@ -112,6 +112,7 @@ module TypeProf::Core
         edges = []
         state = :left
         j = nil
+        rights_size = rights ? rights.size : 0
         @elems.each_with_index do |elem, i|
           case state
           when :left
@@ -123,7 +124,7 @@ module TypeProf::Core
               redo
             end
           when :rest
-            if @elems.size - i > rights.size
+            if @elems.size - i > rights_size
               edges << [elem, rest_elem]
             else
               state = :right

--- a/scenario/variable/masgn_nested.rb
+++ b/scenario/variable/masgn_nested.rb
@@ -1,0 +1,34 @@
+## update
+def test_nested_destructuring
+  a, (b, c) = [1, [2, 3]]
+  [a, b, c]
+end
+
+def test_nested_with_strings
+  x, (y, z) = ["foo", ["bar", "baz"]]
+  [x, y, z]
+end
+
+def test_deeper_nesting
+  a, (b, (c, d)) = [1, [2, [3, 4]]]
+  [a, b, c, d]
+end
+
+def test_nested_with_rest
+  a, (b, *rest) = [1, [2, 3, 4]]
+  [a, b, rest]
+end
+
+def test_nested_with_rest_and_rights
+  a, (b, *rest, c) = [1, [2, 3, 4, 5]]
+  [a, b, rest, c]
+end
+
+## assert
+class Object
+  def test_nested_destructuring: -> [Integer, Integer, Integer]
+  def test_nested_with_strings: -> [String, String, String]
+  def test_deeper_nesting: -> [Integer, Integer, Integer, Integer]
+  def test_nested_with_rest: -> [Integer, Integer, Array[Integer]]
+  def test_nested_with_rest_and_rights: -> [Integer, Integer, Array[Integer], Integer]
+end


### PR DESCRIPTION
This commit adds support for nested destructuring assignments like
`a, (b, c) = [1, [2, 3]]`, which previously caused a
"RuntimeError: not supported yet: multi_target_node" error.

Changes:
- Add MultiTargetNode class to handle nested destructuring targets
- Extend create_target_node to support :multi_target_node type
- Add nil guards for `rights` parameter in MAsgnBox and Type::Array#splat_assign
- Add comprehensive test cases for nested destructuring patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
