### PR TITLE
Fix crash when singleton types are passed to generic methods

### DIFF
--- a/lib/typeprof/core/env.rb
+++ b/lib/typeprof/core/env.rb
@@ -116,6 +116,10 @@ module TypeProf::Core
         base_ty.mod.type_params.zip(base_ty.args) do |param, arg|
           ty_env[param] = arg || Source.new
         end
+      elsif base_ty.is_a?(Type::Singleton)
+        base_ty.mod.type_params&.each do |param|
+          ty_env[param] = Source.new
+        end
       end
       args = mod.type_params.zip(type_args).map do |param, arg|
         arg && changes ? arg.covariant_vertex(self, changes, ty_env) : Source.new

--- a/scenario/regressions/singleton-type-param.rb
+++ b/scenario/regressions/singleton-type-param.rb
@@ -1,0 +1,7 @@
+## update
+# Passing class constants (Singleton types) to methods like `all?`
+# should not crash with "unknown type variable" error
+[].all?(Array)
+[].all?(Hash)
+
+## assert


### PR DESCRIPTION
Previously, TypeProf would crash with "unknown type variable: Elem" when
a class constant like `Array` or `Hash` was passed to methods like `all?`:

    [].all?(Array)  # => RuntimeError: unknown type variable: Elem

This happened because type parameters of Singleton types were not
registered in ty_env when resolving generic method signatures.

This commit fixes the issue by handling Type::Singleton in
get_instance_type, registering its type parameters with Source.new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
