### PR TITLE
Fix crash in break in loop

### DIFF
--- a/scenario/control/break2.rb
+++ b/scenario/control/break2.rb
@@ -1,0 +1,67 @@
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    break count if count == 3
+  end
+end
+
+## assert
+class Object
+  def foo: -> Integer
+end
+
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    begin
+      break count if count == 3
+    rescue
+      break count
+    end
+  end
+end
+
+## assert
+class Object
+  def foo: -> Integer
+end
+
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    begin
+      break count if count == 3
+    rescue
+      break 'str'
+    end
+  end
+end
+
+## assert
+class Object
+  def foo: -> (Integer | String)
+end
+
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    begin
+      # break count if count == 3
+    rescue
+      break 'str'
+    end
+  end
+end
+
+## assert
+class Object
+  def foo: -> String
+end


### PR DESCRIPTION
This PR fixes an error that occurs when breaking out of a loop.

## Reproduction

The following code crashes when analyzed.

```rb
def foo
  count = 0
  loop do
    count += 1
    begin
      break count if count == 3
    rescue
      break count
    end
  end
end
```

## Approach

A bridge Vertex is added between src and dst to prevent duplication.