### PR TITLE
Add RBS type definition file jump to typeDefinition LSP feature

### DIFF
--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -203,11 +203,20 @@ module TypeProf::Core
         if node.ret
           ty_defs = []
           node.ret.types.map do |ty, _source|
-            if ty.is_a?(Type::Instance)
-              ty.mod.module_decls.each do |mdecl|
-                # TODO
+            mod = case ty
+                  when Type::Instance, Type::Singleton
+                    ty.mod
+                  else
+                    base = ty.base_type(@genv)
+                    base.mod if base.is_a?(Type::Instance)
+                  end
+
+            if mod
+              mod.module_decls.each do |mdecl|
+                decl_path = mdecl.lenv.path
+                ty_defs << [decl_path, mdecl.code_range] if decl_path
               end
-              ty.mod.module_defs.each do |mdef_node|
+              mod.module_defs.each do |mdef_node|
                 ty_defs << [mdef_node.lenv.path, mdef_node.code_range]
               end
             end

--- a/test/fixtures/type_definition/sig/test.rbs
+++ b/test/fixtures/type_definition/sig/test.rbs
@@ -1,0 +1,2 @@
+class Foo
+end

--- a/test/fixtures/type_definition/test.rb
+++ b/test/fixtures/type_definition/test.rb
@@ -1,0 +1,5 @@
+class Foo
+end
+
+foo = Foo.new
+foo

--- a/test/fixtures/type_definition/typeprof.conf.json
+++ b/test/fixtures/type_definition/typeprof.conf.json
@@ -1,0 +1,5 @@
+{
+  "typeprof_version": "experimental",
+  "analysis_unit_dirs": ["."],
+  "sig_dirs": ["sig"]
+}


### PR DESCRIPTION
## Summary

Previously, typeDefinition only jumped to Ruby class/module definitions.

This change enables jumping to RBS declaration files from:
- Class/module constants (e.g., Foo in Foo.new)
- Local variables and instance variables holding class instances

Also adds tests for both scenarios.

## Screenshots

### Jumping from class constant

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/82a0f2b5-9b81-445e-98fd-0da70396d8c5" />


### Jumping from local variable

<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/3ed789de-9c6a-4031-a745-46e5b876583b" />

