### PR TITLE
Fix RBS::ParsingError when block argument is assigned to rest keywords hash

### DIFF
--- a/lib/typeprof/core/type.rb
+++ b/lib/typeprof/core/type.rb
@@ -188,7 +188,7 @@ module TypeProf::Core
       end
 
       def show
-        "<Proc>"
+        "Proc"
       end
     end
 

--- a/scenario/block/block_to_hash_with_kwargs.rb
+++ b/scenario/block/block_to_hash_with_kwargs.rb
@@ -1,0 +1,12 @@
+## update
+def foo(**opts, &block)
+  opts[:callback] = block
+  opts
+end
+
+foo(key: 1) {}
+
+## assert
+class Object
+  def foo: (**Integer | Proc) -> Hash[:key, Integer | Proc]
+end


### PR DESCRIPTION
The following code caused RBS::ParsingError:

```ruby
# issue.rb
def foo(**opts, &block)
  opts[:callback] = block
  opts
end
foo(key: 1) {}
```

```bash
$ bin/typeprof issue.rb
# TypeProf 0.31.1

# issue.rb
/Users/sinsoku/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rbs-3.10.0/lib/rbs/parser_aux.rb:10:in 'RBS::Parser._parse_type': RBS::ParsingError
        from /Users/sinsoku/.local/share/mise/installs/ruby/4.0.0/lib/ruby/gems/4.0.0/gems/rbs-3.10.0/lib/rbs/parser_aux.rb:10:in 'RBS::Parser.parse_type'
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/type.rb:20:in 'TypeProf::Core::Type.extract_hash_value_type'
        from /Users/sinsoku/ghq/github.com/ruby/typeprof/lib/typeprof/core/graph/box.rb:647:in 'TypeProf::Core::MethodDefBox#show'
```

Type::Proc#show returned `<Proc>` which is not valid RBS syntax.
MethodDefBox#show calls extract_hash_value_type to parse rest_keywords
type with RBS::Parser, causing ParsingError when the type contains `<Proc>`.

Changed Type::Proc#show to return `Proc` for RBS compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
