### PR TITLE
Prevent `Hash#[]=` on local variables from polluting parameter types

### DIFF
--- a/lib/typeprof/core/builtin.rb
+++ b/lib/typeprof/core/builtin.rb
@@ -111,9 +111,16 @@ module TypeProf::Core
 
     def hash_aset(changes, node, ty, a_args, ret)
       if a_args.positionals.size == 2
+        val = a_args.positionals[1]
+
+        # Skip backflow for local variable receivers (handled by HashAsetBox)
+        if node.recv.is_a?(AST::LocalVariableReadNode)
+          changes.add_edge(@genv, val, ret)
+          return true
+        end
+
         case ty
         when Type::Hash
-          val = a_args.positionals[1]
           idx = node.positional_args[0]
           if idx.is_a?(AST::SymbolNode) && ty.get_value(idx.lit)
             # TODO: how to handle new key?

--- a/lib/typeprof/core/graph/change_set.rb
+++ b/lib/typeprof/core/graph/change_set.rb
@@ -137,6 +137,11 @@ module TypeProf::Core
       @new_boxes[key] ||= InstanceTypeBox.new(@node, genv, singleton_ty_vtx)
     end
 
+    def add_hash_aset_box(genv, recv, key_sym, val_vtx, out_vtx)
+      key = [:hash_aset, recv, key_sym, val_vtx, out_vtx]
+      @new_boxes[key] ||= HashAsetBox.new(@node, genv, recv, key_sym, val_vtx, out_vtx)
+    end
+
     def add_diagnostic(meth, msg, node = @node)
       @new_diagnostics << TypeProf::Diagnostic.new(node, meth, msg)
     end

--- a/scenario/block/block_to_hash_with_kwargs.rb
+++ b/scenario/block/block_to_hash_with_kwargs.rb
@@ -8,5 +8,5 @@ foo(key: 1) {}
 
 ## assert
 class Object
-  def foo: (**Integer) -> { key: Integer }
+  def foo: (**Integer) -> { key: Integer, callback: Proc }
 end

--- a/scenario/hash/hash_aset.rb
+++ b/scenario/hash/hash_aset.rb
@@ -1,0 +1,22 @@
+## update
+def foo(options)
+  return if options[:skip]
+
+  options[:name] = "str"
+  bar(options)
+  nil
+end
+
+def bar(options)
+  options[:age] = 10
+  nil
+end
+
+args = Hash.new
+foo(args)
+
+## assert
+class Object
+  def foo: (Hash[:skip, untyped]) -> nil
+  def bar: (Hash[:name | :skip, String]) -> nil
+end

--- a/scenario/hash/hash_aset_conditional.rb
+++ b/scenario/hash/hash_aset_conditional.rb
@@ -1,0 +1,25 @@
+## update
+def foo(flag)
+  h = {}
+  h[:a] = 1 if flag
+  h[:b] = 2 if flag
+  h[:c] = 3 if flag
+  h[:d] = 4 if flag
+  h[:e] = 5 if flag
+  h[:f] = 6 if flag
+  h[:g] = 7 if flag
+  h[:h] = 8 if flag
+  h[:i] = 9 if flag
+  h[:j] = 10 if flag
+  h[:k] = 11 if flag
+  h[:l] = 12 if flag
+  h[:m] = 13 if flag
+  h[:n] = 14 if flag
+  h[:o] = 15 if flag
+  h
+end
+
+## assert
+class Object
+  def foo: (untyped) -> ({  } | { a: Integer } | { a: Integer, b: Integer } | { a: Integer, b: Integer, c: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer, j: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer, j: Integer, k: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer, j: Integer, k: Integer, l: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer, j: Integer, k: Integer, l: Integer, m: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer, j: Integer, k: Integer, l: Integer, m: Integer, n: Integer } | { a: Integer, b: Integer, c: Integer, d: Integer, e: Integer, f: Integer, g: Integer, h: Integer, i: Integer, j: Integer, k: Integer, l: Integer, m: Integer, n: Integer, o: Integer })
+end

--- a/scenario/hash/hash_aset_loop.rb
+++ b/scenario/hash/hash_aset_loop.rb
@@ -1,0 +1,14 @@
+## update
+def foo(options)
+  while options[:flag]
+    options[:name] = "str"
+  end
+  nil
+end
+
+foo(Hash.new)
+
+## assert
+class Object
+  def foo: (Hash[:flag, untyped]) -> nil
+end


### PR DESCRIPTION
When `Hash#[]=` was called on a local variable inside a method, the
assigned key/value types flowed back into the method's parameter type.
This caused type explosion in real-world code like Action Pack's
`url_for`, where the parameter type grew into a deeply nested recursive
Hash type.

Introduce HashAsetBox to handle `Hash#[]=` on local variables with
flow-sensitive tracking. Instead of modifying the original hash type
via backflow, it creates a new variable version with the updated type,
so the parameter type only reflects types from call sites.

fixes #362
