### PR TITLE
Add timeout-minutes to CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
           - ruby: "3.3"
             rubyopt: "--enable-frozen-string-literal"
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby


### PR DESCRIPTION
TypeProf may cause infinite loops due to implementation mistakes,
so set a timeout to avoid wasting CI execution time.

ref: https://github.com/ruby/typeprof/pull/363#issuecomment-3866271644
