### PR TITLE
Fix crash in break in loop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    typeprof (0.31.0)
+    typeprof (0.31.1)
       prism (>= 1.4.0)
       rbs (>= 3.6.0)
 

--- a/lib/typeprof/core/ast/control.rb
+++ b/lib/typeprof/core/ast/control.rb
@@ -203,7 +203,7 @@ module TypeProf::Core
 
       def install0(genv)
         arg = @arg.install(genv)
-        @changes.add_edge(genv, arg, @lenv.get_break_vtx)
+        @changes.add_edge(genv, arg.new_vertex(genv, self), @lenv.get_break_vtx)
         Source.new()
       end
     end

--- a/scenario/control/break2.rb
+++ b/scenario/control/break2.rb
@@ -1,0 +1,67 @@
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    break count if count == 3
+  end
+end
+
+## assert
+class Object
+  def foo: -> Integer
+end
+
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    begin
+      break count if count == 3
+    rescue
+      break count
+    end
+  end
+end
+
+## assert
+class Object
+  def foo: -> Integer
+end
+
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    begin
+      break count if count == 3
+    rescue
+      break 'str'
+    end
+  end
+end
+
+## assert
+class Object
+  def foo: -> (Integer | String)
+end
+
+## update
+def foo
+  count = 0
+  loop do
+    count += 1
+    begin
+      # break count if count == 3
+    rescue
+      break 'str'
+    end
+  end
+end
+
+## assert
+class Object
+  def foo: -> String
+end


### PR DESCRIPTION
This change avoids multi-edges by creating an intermediate vertex between an `break` argument and its iterator's result.

Fixes #356