### PR TITLE
Fix infinite loop when block has multiple params for sort_by etc

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -139,7 +139,11 @@ module TypeProf::Core
           end
 
           blk_f_ary_arg = Vertex.new(self)
-          @changes.add_masgn_box(genv, blk_f_ary_arg, blk_f_args, nil, nil) # TODO: support splat "do |a, *b, c|"
+          # TODO: support splat "do |a, *b, c|"
+          blk_f_args.each_with_index do |f_arg, i|
+            elem_vtx = @changes.add_splat_box(genv, blk_f_ary_arg, i).ret
+            @changes.add_edge(genv, elem_vtx, f_arg)
+          end
           block = Block.new(self, blk_f_ary_arg, blk_f_args, @block_body.lenv.next_boxes)
           blk_ty = Source.new(Type::Proc.new(genv, block))
         elsif @block_pass

--- a/lib/typeprof/core/env/method.rb
+++ b/lib/typeprof/core/env/method.rb
@@ -94,12 +94,7 @@ module TypeProf::Core
 
     def accept_args(genv, changes, caller_positionals)
       if caller_positionals.size == 1 && @f_args.size >= 2
-        single_arg = caller_positionals[0]
-
-        @f_args.each_with_index do |f_arg, i|
-          elem_vtx = changes.add_splat_box(genv, single_arg, i).ret
-          changes.add_edge(genv, elem_vtx, f_arg)
-        end
+        changes.add_edge(genv, caller_positionals[0], @f_ary_arg)
       else
         caller_positionals.zip(@f_args) do |a_arg, f_arg|
           changes.add_edge(genv, a_arg, f_arg) if f_arg

--- a/scenario/block/sort_by_multi_param.rb
+++ b/scenario/block/sort_by_multi_param.rb
@@ -1,0 +1,51 @@
+## update
+def foo
+  { a: 1 }.sort_by do |key_value|
+    key_value
+  end
+end
+
+def bar
+  { a: 1 }.sort_by do |key, value|
+    key
+  end
+end
+
+def baz
+  { a: 1 }.sort_by do |(key, value)|
+    key
+  end
+end
+
+## assert
+class Object
+  def foo: -> Array[[:a, Integer]]
+  def bar: -> Array[[:a, Integer]]
+  def baz: -> Array[[:a, Integer]]
+end
+
+## update
+def foo
+  { 'a' => 1 }.sort_by do |key_value|
+    key_value
+  end
+end
+
+def bar
+  { 'a' => 1 }.sort_by do |key, value|
+    key
+  end
+end
+
+def baz
+  { 'a' => 1 }.sort_by do |(key, value)|
+    key
+  end
+end
+
+## assert
+class Object
+  def foo: -> Array[[String, Integer]]
+  def bar: -> Array[[String, Integer]]
+  def baz: -> Array[[String, Integer]]
+end


### PR DESCRIPTION
This PR fixes an infinite loop that occurs when a multi-parameter block is passed to methods like `sort_by`.

## Reproduction

The following code causes the analysis to hang.

```rb
def OK_1
  { a: 1 }.sort_by do |key_value|
    key_value
  end
end

def OK_2
  { a: 1 }.sort_by do |(key, value)|
    key
  end
end

def NG
  { a: 1 }.sort_by do |key, value|
    key
  end
end
```

## Approach

SplatBox creation is moved from the run phase (`Block#accept_args`) to the install phase (`CallBaseNode#install0`), and `accept_args` now just connects an edge to the pre-existing `@f_ary_arg` vertex. This keeps the graph structure stable across re-runs and prevents the infinite loop caused by typecheck trigger edges.
