### PR TITLE
Add --exclude option to skip files matching glob patterns

### DIFF
--- a/lib/typeprof/cli/cli.rb
+++ b/lib/typeprof/cli/cli.rb
@@ -12,6 +12,7 @@ module TypeProf::CLI
       output = nil
       rbs_collection_path = nil
       initialize_config_file = false
+      exclude_patterns = []
 
       opt.separator ""
       opt.separator "Options:"
@@ -25,6 +26,7 @@ module TypeProf::CLI
       opt.on("--version", "Display typeprof version") { cli_options[:display_version] = true }
       opt.on("--collection PATH", "File path of collection configuration") { |v| rbs_collection_path = v }
       opt.on("--no-collection", "Ignore collection configuration") { rbs_collection_path = :no }
+      opt.on("--exclude PATTERN", "Exclude files matching glob PATTERN (can be specified multiple times)") { |v| exclude_patterns << v }
       opt.on("--lsp", "LSP server mode") do |v|
         core_options[:display_indicator] = false
         cli_options[:lsp] = true
@@ -65,6 +67,7 @@ module TypeProf::CLI
         output_errors: false,
         output_parameter_names: false,
         output_source_locations: false,
+        exclude_patterns: exclude_patterns,
       }.merge(core_options)
 
       @lsp_options = {
@@ -189,7 +192,8 @@ module TypeProf::CLI
         {
           "typeprof_version": "experimental",
           "rbs_dir": "sig/",
-          "analysis_unit_dirs": #{exist_dirs.inspect}
+          "analysis_unit_dirs": #{exist_dirs.inspect},
+          // "exclude": ["**/templates/**/*.rb"],
           // "diagnostic_severity": "warning"
         }
       JSONC

--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -39,10 +39,10 @@ module TypeProf::Core
 
     def add_workspace(rb_folder, rbs_folder)
       Dir.glob(File.expand_path(rb_folder + "/**/*.{rb,rbs}")) do |path|
-        update_file(path, nil)
+        update_file(path, nil) unless exclude_files.include?(path)
       end
       Dir.glob(File.expand_path(rbs_folder + "/**/*.{rb,rbs}")) do |path|
-        update_file(path, nil)
+        update_file(path, nil) unless exclude_files.include?(path)
       end
     end
 
@@ -512,6 +512,7 @@ module TypeProf::Core
           i += 1
         end
 
+        next if exclude_files.include?(File.expand_path(file))
         res = update_file(file, File.read(file))
 
         if res
@@ -541,6 +542,14 @@ module TypeProf::Core
         end
         output.puts dump_declarations(file)
       end
+    end
+
+    private
+
+    def exclude_files
+      @exclude_files ||= (@options[:exclude_patterns] || []).each_with_object(::Set.new) { |pattern, set|
+        Dir.glob(File.expand_path(pattern)) { |path| set << path }
+      }
     end
   end
 end

--- a/lib/typeprof/lsp/server.rb
+++ b/lib/typeprof/lsp/server.rb
@@ -104,6 +104,7 @@ module TypeProf::LSP
                 puts "unknown severity: #{ severity }"
               end
             end
+            @core_options[:exclude_patterns] = conf[:exclude] if conf[:exclude]
             conf[:analysis_unit_dirs].each do |dir|
               dir = File.expand_path(dir, path)
               core = @cores[dir] = TypeProf::Core::Service.new(@core_options)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -111,6 +111,17 @@ module TypeProf
       end)
     end
 
+    def test_e2e_exclude
+      assert_equal(<<~END, test_run("exclude_test", ["--exclude", "**/templates/**", "."]))
+        # TypeProf #{ TypeProf::VERSION }
+
+        # ./lib/main.rb
+        class Object
+          def foo: (String) -> String
+        end
+      END
+    end
+
     def test_lsp_options_with_lsp_mode
       assert_nothing_raised { TypeProf::CLI::CLI.new(["--lsp", "--stdio"]) }
     end

--- a/test/fixtures/exclude_test/lib/main.rb
+++ b/test/fixtures/exclude_test/lib/main.rb
@@ -1,0 +1,5 @@
+def foo(n)
+  n
+end
+
+foo("str")

--- a/test/fixtures/exclude_test/templates/page.rb
+++ b/test/fixtures/exclude_test/templates/page.rb
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <h1><%= title %></h1>
+  <p><%= content %></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds --exclude option to skip files matching glob patterns from analysis.

Some projects contain .rb files that are not valid Ruby syntax, such as:
- ERB templates with .rb extension (e.g., [Devise's migration.rb](https://github.com/heartcombo/devise/blob/v5.0.1/lib/generators/active_record/templates/migration.rb))
- .rb files embedding RBS syntax for testing (e.g., [TypeProf's scenario files](https://github.com/ruby/typeprof/tree/v0.31.1/scenario))

## CLI

```bash
$ typeprof --exclude "**/templates/**/*.rb" lib/
```

The --exclude option can be specified multiple times.

## LSP

Add the exclude key to typeprof.conf.jsonc:

```json
{
  "typeprof_version": "experimental",
  "rbs_dir": "sig/",
  "analysis_unit_dirs": ["lib/"],
  "exclude": ["**/templates/**/*.rb"]
}
```

## Note

This can also be useful as a workaround to skip files that cause infinite loops or errors during analysis.
