### PR TITLE
Fix keyword-as-hash handling for methods without keyword params

### DIFF
--- a/lib/typeprof/core/ast/method.rb
+++ b/lib/typeprof/core/ast/method.rb
@@ -37,6 +37,7 @@ module TypeProf::Core
           opt_keywords: [],
           opt_keyword_defaults: [],
           rest_keywords: nil,
+          no_keywords: false,
           block: nil,
         }
       end
@@ -64,6 +65,7 @@ module TypeProf::Core
       req_keywords = []
       opt_keywords = []
       opt_keyword_defaults = []
+      no_keywords = false
 
       raw_args.keywords.each do |kw|
         case kw.type
@@ -83,7 +85,7 @@ module TypeProf::Core
         rest_positionals = :"..."
         rest_keywords = :"..."
       when Prism::NoKeywordsParameterNode
-        # what to do?
+        no_keywords = true
       when nil
         # nothing to do
       else
@@ -102,6 +104,7 @@ module TypeProf::Core
         opt_keywords:,
         opt_keyword_defaults:,
         rest_keywords:,
+        no_keywords:,
         block:,
         args_code_ranges:
       }
@@ -144,6 +147,7 @@ module TypeProf::Core
         @opt_keywords = h[:opt_keywords]
         @opt_keyword_defaults = h[:opt_keyword_defaults]
         @rest_keywords = h[:rest_keywords]
+        @no_keywords = h[:no_keywords]
         @block = h[:block]
         @args_code_ranges = h[:args_code_ranges] || []
 
@@ -163,6 +167,7 @@ module TypeProf::Core
       attr_reader :opt_keywords
       attr_reader :opt_keyword_defaults
       attr_reader :rest_keywords
+      attr_reader :no_keywords
       attr_reader :block
       attr_reader :body
       attr_reader :rbs_method_type
@@ -186,6 +191,7 @@ module TypeProf::Core
         req_keywords:,
         opt_keywords:,
         rest_keywords:,
+        no_keywords:,
         block:,
         reusable:,
       }

--- a/lib/typeprof/core/env/method.rb
+++ b/lib/typeprof/core/env/method.rb
@@ -41,6 +41,17 @@ module TypeProf::Core
       ActualArguments.new(positionals, splat_flags, keywords, block)
     end
 
+    def with_keywords_as_last_positional_hash
+      return self unless @keywords
+
+      ActualArguments.new(
+        @positionals + [@keywords],
+        @splat_flags + [false],
+        nil,
+        @block
+      )
+    end
+
     def get_rest_args(genv, changes, start_rest, end_rest)
       vtxs = []
 

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -491,6 +491,8 @@ module TypeProf::Core
     end
 
     def pass_arguments(changes, genv, a_args)
+      a_args = normalize_keyword_hash_argument_for_def(a_args)
+
       if a_args.splat_flags.any?
         # there is at least one splat actual argument
 
@@ -605,6 +607,15 @@ module TypeProf::Core
       end
 
       return true
+    end
+
+    def normalize_keyword_hash_argument_for_def(a_args)
+      return a_args unless a_args.keywords
+      return a_args if @node.no_keywords
+      return a_args if @node.rest_keywords
+      return a_args unless @node.req_keywords.empty? && @node.opt_keywords.empty?
+
+      a_args.with_keywords_as_last_positional_hash
     end
 
     def call(changes, genv, a_args, ret)

--- a/scenario/args/keyword-as-hash.rb
+++ b/scenario/args/keyword-as-hash.rb
@@ -7,5 +7,5 @@ foo(x: 1)
 
 ## assert
 class Object
-  def foo: (Hash[:x, Integer]) -> Hash[:x, Integer]
+  def foo: ({ x: Integer }) -> { x: Integer }
 end


### PR DESCRIPTION
This PR fixes TypeProf’s handling of calls like `foo(x: 1)` when the callee does not declare keyword parameters.(`scenario/known-issues/keywords.rb`.)  

```ruby
def foo(a)
  a
end

foo(x: 1)
```

In those cases, keyword arguments are now treated as a trailing positional hash (Ruby-compatible), improving inference from `untyped` to record/hash types.

## Details

- Track `Prism::NoKeywordsParameterNode` (`**nil`) as `no_keywords` in method AST metadata.
- Add `ActualArguments#with_keywords_as_last_positional_hash` to centralize argument normalization.
- Normalize keyword args in `MethodDefBox#pass_arguments` only when:
  - keyword args are present,
  - the method has no required/optional/rest keyword params,
  - and the method is not `**nil`.
- Promote the scenario from `scenario/known-issues/keywords.rb` to `scenario/args/keyword-as-hash.rb`.

