### PR TITLE
Fix superclass constant resolution to avoid self-reference

### DIFF
--- a/lib/typeprof/core/ast/module.rb
+++ b/lib/typeprof/core/ast/module.rb
@@ -101,7 +101,11 @@ module TypeProf::Core
       def define0(genv)
         if @static_cpath && @superclass_cpath
           const = @superclass_cpath.define(genv)
-          const.followers << genv.resolve_cpath(@static_cpath) if const
+          if const
+            const.exclude_cpath = @static_cpath
+            const.refresh(genv)
+            const.followers << genv.resolve_cpath(@static_cpath)
+          end
         end
         super(genv)
       end

--- a/scenario/regressions/superclass-self-reference.rb
+++ b/scenario/regressions/superclass-self-reference.rb
@@ -1,0 +1,19 @@
+## update: model.rb
+class Foo
+  def value = 1
+end
+
+module Bar
+  class Foo < Foo
+  end
+end
+
+## update: test.rb
+def call
+  Bar::Foo.new.value
+end
+
+## assert: test.rb
+class Object
+  def call: -> Integer
+end


### PR DESCRIPTION
This change fixes superclass constant resolution for nested `class Foo < Foo` so the resolver no longer picks the class currently being defined.  
It introduces an exclusion cpath on `StaticRead` and applies it from `ClassNode#define0` before re-resolving the superclass read.  
A regression scenario was also added at `scenario/regressions/superclass-self-reference.rb`.

```rb
## update: model.rb
class Foo
  def value = 1
end

module Bar
  class Foo < Foo
  end
end

## update: test.rb
def call
  Bar::Foo.new.value
end
```

With this case, TypeProf now consistently infers `def call: -> Integer` instead of falling back to `untyped`.