### PR TITLE
Skip allocating depended_* arrays for non-Box ChangeSets

### DIFF
--- a/lib/typeprof/core/graph/change_set.rb
+++ b/lib/typeprof/core/graph/change_set.rb
@@ -12,14 +12,16 @@ module TypeProf::Core
       @new_boxes = {}
       @diagnostics = []
       @new_diagnostics = []
-      @depended_value_entities = []
-      @new_depended_value_entities = []
-      @depended_method_entities = []
-      @new_depended_method_entities = []
-      @depended_static_reads = []
-      @new_depended_static_reads = []
-      @depended_superclasses = []
-      @new_depended_superclasses = []
+      if target
+        @depended_value_entities = []
+        @new_depended_value_entities = []
+        @depended_method_entities = []
+        @new_depended_method_entities = []
+        @depended_static_reads = []
+        @new_depended_static_reads = []
+        @depended_superclasses = []
+        @new_depended_superclasses = []
+      end
     end
 
     attr_reader :node, :target, :covariant_types, :contravariant_types, :edges, :boxes, :diagnostics
@@ -184,6 +186,8 @@ module TypeProf::Core
       end
       @diagnostics, @new_diagnostics = @new_diagnostics, @diagnostics
       @new_diagnostics.clear
+
+      return unless @target
 
       @depended_value_entities.each do |ve|
         ve.read_boxes.delete(@target) || raise


### PR DESCRIPTION
ChangeSet's depended_* fields (8 arrays) are only used by Box ChangeSets but were allocated for all ChangeSets. Since ~80% of ChangeSets are for AST Nodes and never use these fields, this guards the allocation with `if target` and skips the processing in `reinstall` with `return unless @target`.

## Benchmark

Replicated TypeProf core sources under unique module names to simulate larger codebases. Median of 3 runs per scale.

| Files | Alloc reduction | Wall time improvement |
|------:|----------------:|---------------------:|
| 120   | -8.9%           | -2.1%                |
| 480   | -8.3%           | -3.1%                |
| 960   | -7.8%           | -4.6%                |

Improvement scales with codebase size.