### PR TITLE
Analyze RBS files before RB files for better type inference

### DIFF
--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -51,8 +51,8 @@ module TypeProf
       assert_equal(<<~END, test_run("syntax_error", ["."]))
         # TypeProf #{ TypeProf::VERSION }
 
-        # failed to analyze: ./syntax_error.rb
         # failed to analyze: ./syntax_error.rbs
+        # failed to analyze: ./syntax_error.rb
       END
     end
 


### PR DESCRIPTION
## Description

Process RBS files first so that type declarations are available during RB type inference.
This avoids redundant re-analysis that occurs when RB files are processed before their corresponding RBS declarations, reducing unnecessary run_all cycles.

## Benchmark

Measured with ruby 3.4.7 (2025-10-08 revision 7a5688e2a2) +PRISM [arm64-darwin25].
I added RBS files to Redmine and measured.

* before: 35.12s
* after: 24.96s

```ruby
#!/usr/bin/env ruby

require "fileutils"

typeprof_dir = File.expand_path("..", __dir__)
redmine_dir = File.join(typeprof_dir, "tmp", "redmine_v6_1_1")

unless Dir.exist?(File.join(redmine_dir, ".git"))
  FileUtils.mkdir_p(File.dirname(redmine_dir))
  system("git clone --branch 6.1.1 --depth 1 https://github.com/redmine/redmine.git #{redmine_dir}", exception: true)
end

Dir.chdir(redmine_dir) do
  unless File.exist?("config/database.yml")
    File.write("config/database.yml", <<~YAML)
      development:
        adapter: sqlite3
        database: db/development.sqlite3
    YAML
  end

  system("bundle add rbs_rails", exception: true) unless File.read("Gemfile").include?("rbs_rails")
  system("bin/rails db:migrate", exception: true) unless File.exist?("db/schema.rb")
  system("bundle exec rbs collection init", exception: true) unless File.exist?("rbs_collection.yaml")
  system("bundle exec rbs collection install", exception: true) unless File.exist?("rbs_collection.lock.yaml")
  system("bundle exec rbs_rails all", exception: true) unless Dir.exist?("sig/rbs_rails")

  t = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  system(File.join(typeprof_dir, "bin/typeprof"), "app", "sig", exception: true)
  puts "Elapsed: %.2fs" % (Process.clock_gettime(Process::CLOCK_MONOTONIC) - t)
end

```
