### PR TITLE
Add GitHub Issue Templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Report an issue with TypeProf you've discovered
+labels: bug
+---
+
+### Ruby / TypeProf version
+
+- Ruby:
+- TypeProf:
+
+### Input
+
+```ruby
+# Paste your Ruby code that reproduces the bug
+```
+
+### Expected behavior
+
+<!-- Describe the expected behavior -->
+
+### Actual behavior
+
+<!-- Describe what actually happened -->
+
+### Additional context
+
+<!-- If you'd like to create a reproduction script, see doc/bug_report_template.rb -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement for TypeProf
+labels: enhancement
+---
+
+### Problem
+
+<!-- Describe the problem you are trying to solve -->
+
+### Proposed solution
+
+<!-- If you have a suggestion, describe it here -->

--- a/doc/bug_report_template.rb
+++ b/doc/bug_report_template.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+
+gemfile(true) do
+  source "https://rubygems.org"
+
+  gem "typeprof"
+  # If you want to test against edge TypeProf replace the previous line with this:
+  # gem "typeprof", github: "ruby/typeprof", branch: "master"
+
+  gem "test-unit"
+end
+
+require "test/unit"
+require "typeprof"
+
+def infer(source)
+  service = TypeProf::Core::Service.new({})
+  service.update_rb_file("(typeprof)", source)
+  service.dump_declarations("(typeprof)")
+end
+
+class BugTest < Test::Unit::TestCase
+  def test_example
+    source = <<~RUBY
+      def foo(n)
+        p n
+        n.to_s
+      end
+
+      p foo(42)
+    RUBY
+
+    expected = <<~RBS
+      class Object
+        def foo: (Integer) -> String
+      end
+    RBS
+
+    assert_equal(expected, infer(source))
+  end
+end


### PR DESCRIPTION
Add GitHub Issue Templates to make it easier for users to report bugs and request features.

This is also in preparation for RubyKaigi 2026, where new users may try TypeProf and want to contribute feedback.
