### PR TITLE
Fix BotFilter to restore types when base exits bot-only state

### DIFF
--- a/lib/typeprof/core/graph/filter.rb
+++ b/lib/typeprof/core/graph/filter.rb
@@ -114,6 +114,9 @@ module TypeProf::Core
       if src_var == @base_vtx
         if @base_vtx.types.size == 1 && @base_vtx.types.include?(genv.bot_type)
           @next_vtx.on_type_removed(genv, self, @types.keys & @next_vtx.types.keys) # XXX: smoke/control/bot2.rb
+        else
+          # base_vtx is no longer bot-only; restore any previously suppressed types
+          @next_vtx.on_type_added(genv, self, @types.keys - @next_vtx.types.keys)
         end
       else
         added_types.each do |ty|

--- a/scenario/flow/begin_rescue_var.rb
+++ b/scenario/flow/begin_rescue_var.rb
@@ -1,0 +1,19 @@
+## update
+def test(cond, val)
+  if cond
+    begin
+      val = val.to_i
+    rescue
+      raise "bad"
+    end
+  end
+  val
+end
+
+test(true, "42")
+test(false, "hello")
+
+## assert
+class Object
+  def test: (bool, String) -> (Integer | String)
+end


### PR DESCRIPTION
When a BotFilter's base_vtx transitions from bot-only to having non-bot types, previously suppressed variable types were not restored. This caused variables assigned inside begin/rescue blocks to lose their types when the rescue clause contained raise (bot).

The fix adds type restoration in on_type_added when the base_vtx is no longer bot-only.