### PR TITLE
Fix optional type typecheck to accept nil

### DIFF
--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -884,6 +884,16 @@ module TypeProf::Core
       end
 
       def typecheck(genv, changes, vtx, subst)
+        # For optional type T?, check if all non-nil types match T.
+        # nil is always acceptable.
+        changes.add_edge(genv, vtx, changes.target)
+        has_non_nil = false
+        vtx.each_type do |ty|
+          next if ty.is_a?(Type::Bot)
+          next if ty == genv.nil_type
+          has_non_nil = true
+        end
+        return true unless has_non_nil
         @type.typecheck(genv, changes, vtx, subst)
       end
 

--- a/scenario/rbs/optional_nil_typecheck.rb
+++ b/scenario/rbs/optional_nil_typecheck.rb
@@ -1,0 +1,21 @@
+## update: test.rbs
+class Object
+  def bar: (Binding?) -> void
+end
+
+## update: test.rb
+eval("hello", nil, "test")
+
+def bar_nil
+  bar(nil)
+end
+
+def bar_binding
+  bar(binding)
+end
+
+## assert
+class Object
+  def bar_nil: -> Object
+  def bar_binding: -> Object
+end


### PR DESCRIPTION
SigTyOptionalNode#typecheck was delegating directly to the inner type's typecheck, which would reject nil values for T? types like Binding?. Now it skips nil types when checking, since nil is always valid for optional types.

This fixes false "wrong type of arguments" for calls like eval("code", nil, "filename") where the second argument is Binding?.