### PR TITLE
Include Hash::_Key interface in Object for correct key? typecheck

### DIFF
--- a/lib/typeprof/core/env.rb
+++ b/lib/typeprof/core/env.rb
@@ -281,6 +281,9 @@ module TypeProf::Core
         class Hash[K, V]
           include _Each[[K, V]]
         end
+        class Object
+          include Hash::_Key
+        end
       RBS
 
       # Loading frequently used modules first will reduces constant resolution

--- a/scenario/hash/key_check.rb
+++ b/scenario/hash/key_check.rb
@@ -1,0 +1,16 @@
+## update
+def test
+  h = { a: 1, b: 2 }
+  h.key?(:a)
+  h.key?("not a symbol")
+  h.key?(Object.new)
+end
+
+test
+
+## assert
+class Object
+  def test: -> bool
+end
+
+## diagnostics


### PR DESCRIPTION
Hash#has_key? accepts _Key interface (hash + eql?) rather than the hash's key type parameter. Adding Object include _Key ensures that any object can be passed to key?/has_key?/include?/member? without type errors.