### PR TITLE
Support .nil? narrowing for local and instance variables

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -270,6 +270,20 @@ module TypeProf::Core
             else
               super
             end
+          when :nil?
+            if @recv.is_a?(LocalVariableReadNode)
+              [
+                Narrowing.new({ @recv.var => Narrowing::NilConstraint.new(true) }),
+                Narrowing.new({ @recv.var => Narrowing::NilConstraint.new(false) })
+              ]
+            elsif @recv.is_a?(InstanceVariableReadNode)
+              [
+                Narrowing.new({ @recv.var => Narrowing::NilConstraint.new(true) }),
+                Narrowing.new({ @recv.var => Narrowing::NilConstraint.new(false) })
+              ]
+            else
+              super
+            end
           when :!
             then_narrowing, else_narrowing = @recv.narrowings
             [else_narrowing, then_narrowing]

--- a/scenario/flow/nil_check.rb
+++ b/scenario/flow/nil_check.rb
@@ -1,0 +1,13 @@
+## update
+def foo(x)
+  unless x.nil?
+    x.to_sym
+  end
+end
+foo(nil)
+foo("hello")
+
+## assert
+class Object
+  def foo: (String?) -> Symbol?
+end


### PR DESCRIPTION
`x.nil?` in conditions now narrows the variable type: the then branch treats x as nil, and the else branch excludes nil. Works with both local variables and instance variables.