### PR TITLE
Support narrowing for if (y = x) assignment in condition

### DIFF
--- a/lib/typeprof/core/ast/variable.rb
+++ b/lib/typeprof/core/ast/variable.rb
@@ -68,6 +68,13 @@ module TypeProf::Core
         super(pos, &blk)
       end
 
+      def narrowings
+        @narrowings ||= [
+          Narrowing.new({ @var => Narrowing::NilConstraint.new(false) }),
+          Narrowing.new({ @var => Narrowing::NilConstraint.new(true) }),
+        ]
+      end
+
       def modified_vars(tbl, vars)
         vars << self.var if tbl.include?(self.var)
       end

--- a/scenario/flow/if_assign.rb
+++ b/scenario/flow/if_assign.rb
@@ -1,0 +1,42 @@
+## update
+def foo(x)
+  if (y = x)
+    y.to_sym
+  end
+end
+foo(nil)
+foo("hello")
+
+## assert
+class Object
+  def foo: (String?) -> Symbol?
+end
+
+## update
+def foo(x, z)
+  if x && (y = z)
+    y.to_sym
+  end
+end
+foo(true, "hello")
+foo(true, nil)
+foo(false, nil)
+
+## assert
+class Object
+  def foo: (bool, String?) -> Symbol?
+end
+
+## update
+def foo(z)
+  if (y = z) && y.length > 0
+    y.to_sym
+  end
+end
+foo("hello")
+foo(nil)
+
+## assert
+class Object
+  def foo: (String?) -> Symbol?
+end


### PR DESCRIPTION
LocalVariableWriteNode now provides narrowings for the assigned variable, so `if (y = x)` correctly narrows y to non-nil in the then branch.