### PR TITLE
Fix NoMethodError in SigTySingletonNode#show due to uninitialized @args

### DIFF
--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -550,7 +550,8 @@ module TypeProf::Core
         name = raw_decl.name
         @cpath = name.namespace.path + [name.name]
         @toplevel = name.namespace.absolute?
-        @args = raw_decl.args.map {|arg| AST.create_rbs_type(arg, lenv) }
+        # RBS::Types::ClassSingleton#args was added in RBS 4.0
+        @args = raw_decl.respond_to?(:args) ? raw_decl.args.map {|arg| AST.create_rbs_type(arg, lenv) } : []
       end
 
       attr_reader :cpath, :toplevel

--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -550,6 +550,7 @@ module TypeProf::Core
         name = raw_decl.name
         @cpath = name.namespace.path + [name.name]
         @toplevel = name.namespace.absolute?
+        @args = raw_decl.args.map {|arg| AST.create_rbs_type(arg, lenv) }
       end
 
       attr_reader :cpath, :toplevel

--- a/scenario/regressions/singleton-show-nil-args.rb
+++ b/scenario/regressions/singleton-show-nil-args.rb
@@ -1,0 +1,11 @@
+## update
+class Foo
+end
+
+#: -> singleton(Foo)
+def test
+  1
+end
+
+## diagnostics
+(6,2)-(6,3): expected: singleton(::Foo); actual: Integer


### PR DESCRIPTION
SigTySingletonNode#initialize did not initialize @args, causing
a NoMethodError when #show was called during return type checking.
This occurred when a method annotated with singleton(X) returned
a mismatched type.
