### PR TITLE
Fix infinite loop in `define_all` for RBS include with same-name nested constant

### DIFF
--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -232,10 +232,10 @@ module TypeProf::Core
       def define0(genv)
         @args.each {|arg| arg.define(genv) }
         const_reads = []
-        const_read = BaseConstRead.new(genv, @cpath.first, @toplevel ? CRef::Toplevel : @lenv.cref, false)
+        const_read = BaseConstRead.new(genv, @cpath.first, @toplevel ? CRef::Toplevel : @lenv.cref, true)
         const_reads << const_read
         @cpath[1..].each do |cname|
-          const_read = ScopedConstRead.new(cname, const_read, false)
+          const_read = ScopedConstRead.new(cname, const_read, true)
           const_reads << const_read
         end
         mod = genv.resolve_cpath(@lenv.cref.cpath)
@@ -281,10 +281,10 @@ module TypeProf::Core
       def define0(genv)
         @args.each {|arg| arg.define(genv) }
         const_reads = []
-        const_read = BaseConstRead.new(genv, @cpath.first, @toplevel ? CRef::Toplevel : @lenv.cref, false)
+        const_read = BaseConstRead.new(genv, @cpath.first, @toplevel ? CRef::Toplevel : @lenv.cref, true)
         const_reads << const_read
         @cpath[1..].each do |cname|
-          const_read = ScopedConstRead.new(cname, const_read, false)
+          const_read = ScopedConstRead.new(cname, const_read, true)
           const_reads << const_read
         end
         mod = genv.resolve_cpath(@lenv.cref.cpath)

--- a/scenario/regressions/include-nested-same-name.rb
+++ b/scenario/regressions/include-nested-same-name.rb
@@ -1,0 +1,25 @@
+# Regression: when a module contains a same-name nested class,
+# RBS `include` resolution used to oscillate between the module
+# and the nested class, causing define_all to loop forever.
+
+## update: test.rbs
+module M
+  class M
+  end
+
+  def foo: () -> String
+end
+
+class C
+  include M
+end
+
+## update: test.rb
+def test
+  C.new.foo
+end
+
+## assert
+class Object
+  def test: -> String
+end


### PR DESCRIPTION
When `module X` contains `class X`, resolving `include X` in RBS
searched the ancestor chain (`search_ancestors=true`), which caused the
resolved constant to flip between X (module) and X::X (class) on
every re-evaluation, looping `define_all` forever.

The .rb side already avoids this via `use_strict_const_scope` in
IncludeMetaNode. Apply the same `strict_const_scope=true` to
SigIncludeNode and SigPrependNode so that include/prepend targets
are resolved through lexical scope only.

fixes #431
