### PR TITLE
Fix crash on empty parentheses () in AST conversion

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -61,6 +61,7 @@ module TypeProf::Core
       while true
         case raw_node.type
         when :parentheses_node
+          return DummyNilNode.new(lenv.code_range_from_node(raw_node), lenv) if raw_node.body.nil?
           raw_node = raw_node.body
         when :implicit_node
           raw_node = raw_node.value

--- a/scenario/misc/parens.rb
+++ b/scenario/misc/parens.rb
@@ -1,0 +1,30 @@
+## update
+def grouping
+  (1 + 2)
+end
+
+def nested
+  ((3))
+end
+
+def empty
+  ()
+end
+
+def with_default(x = ())
+  x
+end
+
+grouping
+nested
+empty
+with_default
+with_default(1)
+
+## assert
+class Object
+  def grouping: -> Integer
+  def nested: -> Integer
+  def empty: -> nil
+  def with_default: (?Integer?) -> Integer?
+end


### PR DESCRIPTION
## Problem

  `TypeProf::Core::AST.create_node` crashes with `NoMethodError` on the empty parentheses expression `()`:

  ```ruby
  require "typeprof"
  TypeProf::Core::Service.new({}).update_rb_file("t.rb", "()")
  # => lib/typeprof/core/ast.rb:62:in 'create_node':
  #    undefined method 'type' for nil (NoMethodError)
  #            case raw_node.type
```