### PR TITLE
Fix NoMethodError when RBS file contains class/module alias decl

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -423,7 +423,7 @@ module TypeProf::Core
 
       raw_decls.map do |raw_decl|
         AST.create_rbs_decl(raw_decl, lenv)
-      end
+      end.compact
     end
 
     def self.create_rbs_decl(raw_decl, lenv)

--- a/scenario/rbs/class-module-alias.rb
+++ b/scenario/rbs/class-module-alias.rb
@@ -1,0 +1,21 @@
+## update: test.rbs
+class Foo
+  def foo: () -> Integer
+end
+class Bar = Foo
+module M
+  def m: () -> String
+end
+module N = M
+
+## update: test.rb
+def test1
+  Foo.new.foo
+end
+
+## assert: test.rb
+class Object
+  def test1: -> Integer
+end
+
+## diagnostics: test.rb


### PR DESCRIPTION
## Summary

Fix `NoMethodError: undefined method 'define' for nil` raised in `Service#update_rbs_file` whenever the workspace contains an RBS file with a class alias or module alias declaration (e.g. `module YAML = Psych`, `class HashWithIndifferentAccess = ActiveSupport::HashWithIndifferentAccess`).

## Background

`AST.create_rbs_decl` has an intentionally empty `when RBS::AST::Declarations::AliasDecl` branch (class/module aliases are not yet implemented and are silently skipped).
However the empty `when` body returns `nil`, and the calling site `AST.parse_rbs` calls `raw_decls.map { ... }` without `.compact`, so the `nil` ends up in the resulting array and later crashes at `decls.each {|decl| decl.define(@genv) }`.

The two other callers of `create_rbs_decl` / `create_rbs_member` already use `.compact` after the `map` (see `Genv#load_core_rbs` in `core/env.rb` and `SigModuleBaseNode#initialize` in `core/ast/sig_decl.rb`). This PR aligns `parse_rbs` with the same pattern.

## Reproduction

Put a single line in `sig/foo.rbs`:

```rbs
module YAML = Psych
```

Start the LSP server: it crashes during workspace initialization with

```
NoMethodError: undefined method 'define' for nil
  decls.each {|decl| decl.define(@genv) }
```

## Fix

Add `.compact` to the `map` in `AST.parse_rbs`. Class/module aliases remain unimplemented (skipped) — proper alias resolution is out of scope for this PR.

## Test plan

- [x] Added `scenario/rbs/class-module-alias.rb` regression test
- [x] `bundle exec rake test` passes (415 tests, 0 failures)
- [x] Verified locally: real-world RBS with `module YAML = Psych` no longer crashes the LSP server
