### PR TITLE
Fix RuntimeError on `()` as a method arg or hash splat value

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -37,7 +37,7 @@ module TypeProf::Core
               @splat_flags << false
             end
           end
-          @positional_args = args.map {|arg| arg ? AST.create_node(arg, lenv) : DummyNilNode.new(code_range, lenv) }
+          @positional_args = args.map {|arg| arg ? AST.create_node(arg, lenv) : nil }
 
           kw = @positional_args.last
           if kw.is_a?(TypeProf::Core::AST::HashNode) && kw.keywords
@@ -119,7 +119,7 @@ module TypeProf::Core
           keyword_args = forward_a_args.keywords
         else
           positional_args = @positional_args.map do |arg|
-            if arg.is_a?(DummyNilNode)
+            if arg.nil?
               @lenv.get_var(:"*anonymous_rest")
             else
               arg.install(genv)

--- a/lib/typeprof/core/ast/value.rb
+++ b/lib/typeprof/core/ast/value.rb
@@ -275,7 +275,7 @@ module TypeProf::Core
             if raw_elem.value
               @vals << AST.create_node(raw_elem.value, lenv)
             else
-              @vals << DummyNilNode.new(code_range, lenv)
+              @vals << nil
             end
             @splat = true
           else
@@ -306,7 +306,7 @@ module TypeProf::Core
               all_symbol_keys = false
             end
           else
-            if val.is_a?(DummyNilNode)
+            if val.nil?
               h = @lenv.get_var(:"**anonymous_keyword")
             else
               h = val.install(genv)

--- a/scenario/misc/parens.rb
+++ b/scenario/misc/parens.rb
@@ -15,11 +15,38 @@ def with_default(x = ())
   x
 end
 
+def in_array
+  [()]
+end
+
+def in_condition
+  if (); 1; end
+end
+
+def take_arg(x); x; end
+
+def empty_as_arg
+  take_arg(())
+end
+
+def empty_as_splat_arg
+  take_arg(*())
+end
+
+def empty_as_kw_splat
+  { **() }
+end
+
 grouping
 nested
 empty
 with_default
 with_default(1)
+in_array
+in_condition
+empty_as_arg
+empty_as_splat_arg
+empty_as_kw_splat
 
 ## assert
 class Object
@@ -27,4 +54,10 @@ class Object
   def nested: -> Integer
   def empty: -> nil
   def with_default: (?Integer?) -> Integer?
+  def in_array: -> [nil]
+  def in_condition: -> Integer?
+  def take_arg: (nil) -> nil
+  def empty_as_arg: -> nil
+  def empty_as_splat_arg: -> nil
+  def empty_as_kw_splat: -> Hash[untyped, untyped]
 end


### PR DESCRIPTION
## Summary

Follow-up to #441. After empty parentheses `()` started producing a `DummyNilNode`, several call/hash sites began misinterpreting `()` as anonymous-forwarding syntax, raising `RuntimeError: *anonymous_rest` or `**anonymous_keyword` from `LocalEnv#get_var`.

Reproducers (all crash on current master):

```ruby
foo(())     # RuntimeError: *anonymous_rest
foo(*())    # RuntimeError: *anonymous_rest
{ **() }    # RuntimeError: **anonymous_keyword
```

## Root cause

`CallBaseNode` and `HashNode` were overloading `DummyNilNode` as a sentinel for bare `*` / `**` forwarding. The placeholder created at parse time when the raw arg/value was `nil` (the anonymous-forwarding case) was later detected with `is_a?(DummyNilNode)` at install time. Once `()` also became a `DummyNilNode`, the two cases collided.

Reported by @sinsoku as the "separate issue" note in #441.

## Fix

Use a plain `nil` as the forwarding-placeholder in `@positional_args` and `@vals`, and check `arg.nil?` / `val.nil?` at install time. `DummyNilNode` is then reserved for actual nil-valued expressions like `()`, with no semantic overlap.

## Test plan

- [x] `scenario/misc/parens.rb` extended with the new cases (also covers @sinsoku's other suggestions: `[()]` and `if (); 1; end`)
- [x] `rake test` passes (425 tests, 817 assertions)
- [x] Existing anonymous-rest forwarding (`scenario/args/anonymous_rest.rb`) still passes