### PR TITLE
Fix NoMethodError in CallBaseNode#modified_vars for anonymous rest

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -247,7 +247,7 @@ module TypeProf::Core
               subnode.modified_vars(tbl, vars)
             end
           else
-            subnode.each {|n| n.modified_vars(tbl, vars) }
+            subnode.each {|n| n&.modified_vars(tbl, vars) }
           end
         end
       end

--- a/scenario/args/anonymous_rest.rb
+++ b/scenario/args/anonymous_rest.rb
@@ -7,10 +7,17 @@ def bar(*)
   nil
 end
 
+def foo_in_if(*)
+  if true
+    bar(*)
+  end
+end
+
 bar(1, "foo")
 
 ## assert
 class Object
   def foo: (*untyped) -> nil
   def bar: (*Integer | String) -> nil
+  def foo_in_if: (*untyped) -> nil
 end


### PR DESCRIPTION
Since ff8a5167, anonymous rest arguments (bare `*`) are represented as
`nil` placeholders in `@positional_args` instead of `DummyNilNode`.
However, `CallBaseNode#modified_vars` iterates the positional args
array without skipping nil, raising NoMethodError when a call with
anonymous rest forwarding appears inside a branch (e.g.
`if cond; bar(*); end`) whose `modified_vars` is walked from
`BranchNode#install0`.

Use safe navigation so nil placeholders are skipped, matching how
`each_subnode` already guards against nil subnodes. Add a regression
case to scenario/args/anonymous_rest.rb.
