### PR TITLE
Enable bundler cache in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,9 +33,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Bundle install
-      run: |
-        bundle install
+        bundler-cache: true
     - name: Run the test suite
       run: |
         bundle exec rake TESTOPT=-v RUBYOPT="${{ matrix.rubyopt }}"


### PR DESCRIPTION
Use ruby/setup-ruby's bundler-cache option to cache installed gems
keyed by Gemfile.lock, reducing CI time spent on bundle install.

The option runs bundle install automatically, so the explicit
Bundle install step was removed.
