### PR TITLE
Fix crash on empty block parameters `||` and `|; x|`

### DIFF
--- a/lib/typeprof/core/ast/call.rb
+++ b/lib/typeprof/core/ast/call.rb
@@ -60,17 +60,24 @@ module TypeProf::Core
             @block_multi_targets = {}
             @block_f_args = case raw_block.parameters
                             when Prism::BlockParametersNode
+                              # `{ || ... }` (empty pipes) and `{ |; x| ... }`
+                              # (block-local-only) yield BlockParametersNode
+                              # whose inner `parameters` is nil.
                               params = raw_block.parameters.parameters
-                              req = params.requireds.each_with_index.map do |n, i|
-                                if n.is_a?(Prism::MultiTargetNode)
-                                  @block_multi_targets[i] = n
-                                  nil
-                                else
-                                  n.name
+                              if params
+                                req = params.requireds.each_with_index.map do |n, i|
+                                  if n.is_a?(Prism::MultiTargetNode)
+                                    @block_multi_targets[i] = n
+                                    nil
+                                  else
+                                    n.name
+                                  end
                                 end
+                                opt = params.optionals.map {|n| n.name }
+                                req + opt
+                              else
+                                []
                               end
-                              opt = params.optionals.map {|n| n.name }
-                              req + opt
                             when Prism::NumberedParametersNode
                               1.upto(raw_block.parameters.maximum).map { |n| :"_#{n}" }
                             when Prism::ItParametersNode
@@ -83,7 +90,7 @@ module TypeProf::Core
             ncref = CRef.new(lenv.cref.cpath, :instance, @mid, lenv.cref)
             nlenv = LocalEnv.new(@lenv.file_context, ncref, {}, @lenv.return_boxes)
             @block_opt_positional_defaults = []
-            if raw_block.parameters.is_a?(Prism::BlockParametersNode)
+            if raw_block.parameters.is_a?(Prism::BlockParametersNode) && raw_block.parameters.parameters
               raw_block.parameters.parameters.optionals.each do |n|
                 @block_opt_positional_defaults << AST.create_node(n.value, nlenv)
               end

--- a/scenario/regressions/empty-block-parameters.rb
+++ b/scenario/regressions/empty-block-parameters.rb
@@ -1,0 +1,13 @@
+## update
+def call_block(&b)
+  b.call
+end
+
+call_block { || 42 }
+
+call_block { |; x| x = 42; x }
+
+## assert
+class Object
+  def call_block: { () -> Integer } -> Integer
+end


### PR DESCRIPTION
Prism returns BlockParametersNode with `parameters: nil` for `{ || ... }`
and `{ |; x| ... }`. CallBaseNode#initialize did not handle this and
raised NoMethodError on `params.requireds`.
