### PR TITLE
Support Symbol#to_proc block inference

### DIFF
--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -43,6 +43,15 @@ module TypeProf::Core
       raise NotImplementedError
     end
 
+    def add_symbol_proc_call_box(changes, genv, sym, caller_positionals)
+      return if caller_positionals.empty?
+
+      recv = caller_positionals.first
+      positionals = caller_positionals[1..]
+      a_args = ActualArguments.new(positionals, ::Array.new(positionals.size, false), nil, nil)
+      changes.add_method_call_box(genv, recv, sym, a_args, false)
+    end
+
     def to_s
       "#{ self.class.to_s.split("::").last }#{ @id ||= $new_id += 1 }"
     end
@@ -382,6 +391,8 @@ module TypeProf::Core
                 end
               end
             end
+          when Type::Symbol
+            resolve_symbol_proc(changes, genv, ty.sym, blk_a_args, rbs_blk, param_map0)
           end
         end
       end
@@ -394,6 +405,13 @@ module TypeProf::Core
         ret_vtx = method_type.return_type.covariant_vertex(genv, changes, param_map0)
         changes.add_edge(genv, ret_vtx, ret)
       end
+    end
+
+    def resolve_symbol_proc(changes, genv, sym, blk_a_args, rbs_blk, param_map)
+      box = add_symbol_proc_call_box(changes, genv, sym, blk_a_args)
+      return unless box
+
+      rbs_blk.return_type.typecheck(genv, changes, box.ret, param_map)
     end
 
     def resolve_overloads(changes, genv, node, param_map, a_args, ret, &blk)
@@ -1026,7 +1044,10 @@ module TypeProf::Core
       called_mdefs = Set.empty
       error_count = 0
       resolve(genv, changes) do |me, ty, mid, orig_ty|
-        if !me
+        if @node.is_a?(AST::YieldNode) && mid == :call && orig_ty.is_a?(Type::Symbol)
+          box = add_symbol_proc_call_box(changes, genv, orig_ty.sym, @a_args.positionals)
+          changes.add_edge(genv, box.ret, @ret) if box
+        elsif !me
           unless @suppress_errors
             if error_count < 3
               meth = @node.mid_code_range ? :mid_code_range : :code_range

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -44,14 +44,14 @@ module TypeProf::Core
       raise NotImplementedError
     end
 
-    def add_symbol_proc_call_box(_changes, genv, sym, caller_positionals)
+    def add_symbol_proc_call_box(_changes, genv, sym, caller_positionals, caller_keywords = nil)
       return if caller_positionals.empty?
 
       recv = caller_positionals.first
       positionals = caller_positionals[1..]
       @symbol_proc_call_boxes ||= {}
-      @symbol_proc_call_boxes[[recv, sym, *positionals]] ||= begin
-        a_args = ActualArguments.new(positionals, ::Array.new(positionals.size, false), nil, nil)
+      @symbol_proc_call_boxes[[recv, sym, *positionals, caller_keywords]] ||= begin
+        a_args = ActualArguments.new(positionals, ::Array.new(positionals.size, false), caller_keywords, nil)
         MethodCallBox.new(@node, genv, recv, sym, a_args, false)
       end
     end
@@ -1056,7 +1056,7 @@ module TypeProf::Core
       error_count = 0
       resolve(genv, changes) do |me, ty, mid, orig_ty|
         if @node.is_a?(AST::YieldNode) && mid == :call && orig_ty.is_a?(Type::Symbol)
-          box = add_symbol_proc_call_box(changes, genv, orig_ty.sym, @a_args.positionals)
+          box = add_symbol_proc_call_box(changes, genv, orig_ty.sym, @a_args.positionals, @a_args.keywords)
           changes.add_edge(genv, box.ret, @ret) if box
         elsif !me
           unless @suppress_errors

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -17,6 +17,7 @@ module TypeProf::Core
       $box_counts[self.class] -= 1
       $box_counts[Box] -= 1
       @destroyed = true
+      destroy_symbol_proc_call_boxes(genv)
       @changes.reinstall(genv) # rollback all changes
     end
 
@@ -43,13 +44,22 @@ module TypeProf::Core
       raise NotImplementedError
     end
 
-    def add_symbol_proc_call_box(changes, genv, sym, caller_positionals)
+    def add_symbol_proc_call_box(_changes, genv, sym, caller_positionals)
       return if caller_positionals.empty?
 
       recv = caller_positionals.first
       positionals = caller_positionals[1..]
-      a_args = ActualArguments.new(positionals, ::Array.new(positionals.size, false), nil, nil)
-      changes.add_method_call_box(genv, recv, sym, a_args, false)
+      @symbol_proc_call_boxes ||= {}
+      @symbol_proc_call_boxes[[recv, sym, *positionals]] ||= begin
+        a_args = ActualArguments.new(positionals, ::Array.new(positionals.size, false), nil, nil)
+        MethodCallBox.new(@node, genv, recv, sym, a_args, false)
+      end
+    end
+
+    def destroy_symbol_proc_call_boxes(genv)
+      return unless @symbol_proc_call_boxes
+      @symbol_proc_call_boxes.each_value { |box| box.destroy(genv) }
+      @symbol_proc_call_boxes = nil
     end
 
     def to_s
@@ -267,6 +277,7 @@ module TypeProf::Core
       me = genv.resolve_method(@cpath, @singleton, @mid)
       me.remove_decl(self)
       me.add_run_all_method_call_boxes(genv)
+      destroy_symbol_proc_call_boxes(genv)
     end
 
     def match_arguments?(genv, changes, param_map, a_args, method_type)

--- a/scenario/block/symbol_to_proc.rb
+++ b/scenario/block/symbol_to_proc.rb
@@ -1,6 +1,7 @@
 ## update: test.rbs
 class Receiver
   def render: (Integer) -> String
+  def render_kw: (key: Integer) -> Float
 end
 
 class Object
@@ -24,10 +25,20 @@ def yield_from_ruby_method
   apply_to("1", &:to_i)
 end
 
+def apply_to_kw(value)
+  yield value, key: 1
+end
+
+def yield_from_ruby_method_kw
+  apply_to_kw(Receiver.new, &:render_kw)
+end
+
 ## assert: test.rb
 class Object
   def map_to_i: -> Array[Integer]
   def yield_to_symbol_proc: -> String
   def apply_to: (String) { (String) -> Integer } -> Integer
   def yield_from_ruby_method: -> Integer
+  def apply_to_kw: (Receiver) { (Receiver) -> Float } -> Float
+  def yield_from_ruby_method_kw: -> Float
 end

--- a/scenario/block/symbol_to_proc.rb
+++ b/scenario/block/symbol_to_proc.rb
@@ -1,0 +1,33 @@
+## update: test.rbs
+class Receiver
+  def render: (Integer) -> String
+end
+
+class Object
+  def yield_receiver: [R] { (Receiver, Integer) -> R } -> R
+end
+
+## update: test.rb
+def map_to_i
+  ["1", "2"].map(&:to_i)
+end
+
+def yield_to_symbol_proc
+  yield_receiver(&:render)
+end
+
+def apply_to(value)
+  yield value
+end
+
+def yield_from_ruby_method
+  apply_to("1", &:to_i)
+end
+
+## assert: test.rb
+class Object
+  def map_to_i: -> Array[Integer]
+  def yield_to_symbol_proc: -> String
+  def apply_to: (String) { (String) -> Integer } -> Integer
+  def yield_from_ruby_method: -> Integer
+end


### PR DESCRIPTION
## Summary

Fixes #414 

Support `Symbol#to_proc` blocks such as `map(&:to_i)`.

This treats a symbol passed as a block as a method call where the first yielded block argument is the receiver and the remaining yielded arguments are method arguments.

## Changes

- Infer `["1", "2"].map(&:to_i)` as `Array[Integer]`
- Support the same Symbol#to_proc behavior for Ruby `yield`
- Add scenario coverage for RBS block calls and Ruby method block calls
