### PR TITLE
Set up release automation via Trusted Publisher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - lib/typeprof/version.rb
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      id-token: write
+    environment:
+      name: release
+      deployment: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          ruby-version: ruby
+
+      - name: Publish a gem
+        uses: rubygems/release-gem@v1
+
+      - name: Create GitHub release
+        run: |
+          tag_name="$(git describe --tags --abbrev=0)"
+          gh release create "${tag_name}" --verify-tag --generate-notes

--- a/tool/bump.rb
+++ b/tool/bump.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+require_relative "../lib/typeprof/version"
+
+REPO = "ruby/typeprof"
+
+create_branch = false
+bump_kind = :patch
+
+OptionParser.new do |opts|
+  opts.banner = "Usage: ruby tool/bump.rb [--minor|--major] [-b|--branch]"
+  opts.on("--minor", "Bump minor version") { bump_kind = :minor }
+  opts.on("--major", "Bump major version") { bump_kind = :major }
+  opts.on("-b", "--branch", "Create a new branch before committing") { create_branch = true }
+end.parse!
+
+maj, min, pat = TypeProf::VERSION.split(".").map(&:to_i)
+nextver = case bump_kind
+  when :patch then "#{maj}.#{min}.#{pat + 1}"
+  when :minor then "#{maj}.#{min + 1}.0"
+  when :major then "#{maj + 1}.0.0"
+  end
+
+branch = "master"
+Dir.chdir(File.expand_path("..", __dir__)) do
+  abort "must be on master" unless `git rev-parse --abbrev-ref HEAD`.strip == "master"
+  abort "working tree not clean" unless `git status --porcelain`.empty?
+
+  if create_branch
+    prev_tag = `gh api repos/#{REPO}/tags --jq '.[0].name'`.strip
+    abort "no previous tag found" if prev_tag.empty?
+    branch = "release-from-#{prev_tag}"
+    system("git switch -c #{branch}", exception: true)
+  end
+
+  version_file = "lib/typeprof/version.rb"
+  File.write(version_file, File.read(version_file).sub(/VERSION = "[^"]+"/, %(VERSION = "#{nextver}")))
+  system("bundle install", exception: true)
+  system("git add -u", exception: true)
+  system("git commit -m 'Bump version to v#{nextver}'", exception: true)
+end
+
+puts "Bumped to v#{nextver} (on #{branch})."


### PR DESCRIPTION
## Motivation / Background

Automate the gem release process so that maintainers only need to
land a version bump commit on master.

## How the release flow works

1. Maintainer runs `ruby tool/bump.rb` to create a version bump
   commit on master.
2. The release workflow detects the change to
   `lib/typeprof/version.rb`, pushes the `vX.Y.Z` tag, publishes
   the gem via Trusted Publishing, and creates a GitHub Release
   with auto-generated notes.

## Required setup

- [x] RubyGems Trusted Publisher is configured (via #448, with
  `release.yml` and `release` environment)

## Notes

- This PR does not introduce a `CHANGELOG.md`. Release notes are
  produced via `gh release create --generate-notes`.
