### PR TITLE
Skip directories ending with `.rb` when collecting analysis targets

### DIFF
--- a/lib/typeprof/cli/cli.rb
+++ b/lib/typeprof/cli/cli.rb
@@ -156,7 +156,7 @@ module TypeProf::CLI
       files = []
       @cli_options[:argv].each do |path|
         if File.directory?(path)
-          files.concat(Dir.glob("#{ path }/**/*.{rb,rbs}"))
+          files.concat(Dir.glob("#{ path }/**/*.{rb,rbs}").select {|f| File.file?(f) })
         elsif File.file?(path)
           files << path
         else

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -156,6 +156,21 @@ module TypeProf
       END
     end
 
+    def test_e2e_dir_with_rb_suffix
+      # A directory whose name ends with `.rb` (e.g. the `http_parser.rb`
+      # gem name appearing in rubygems' VCR cassettes) must be skipped,
+      # not opened as a Ruby file.
+      # https://github.com/rubygems/rubygems/tree/v4.0.11/bundler/spec/support/artifice/vcr_cassettes/realworld/index.rubygems.org/info/http_parser.rb
+      assert_equal(<<~END, test_run("dir_with_rb_suffix", ["."]))
+        # TypeProf #{ TypeProf::VERSION }
+
+        # ./main.rb
+        class Object
+          def foo: (String) -> String
+        end
+      END
+    end
+
     def test_e2e_show_stats
       result = test_run("show_stats", ["--no-show-typeprof-version", "--show-stats", "."])
       stats = result[/# TypeProf Evaluation Statistics.*/m]

--- a/test/fixtures/dir_with_rb_suffix/main.rb
+++ b/test/fixtures/dir_with_rb_suffix/main.rb
@@ -1,0 +1,5 @@
+def foo(n)
+  n
+end
+
+foo("str")


### PR DESCRIPTION
`Dir.glob("**/*.{rb,rbs}")` matches not only files but also directories whose names end with `.rb` or `.rbs`.
Such directories exist in real projects (e.g. the `http_parser.rb` gem directory inside rubygems' VCR cassettes), and `Service#batch` then crashes with `Errno::EISDIR` while trying to `File.read` them.

Filter the glob result to regular files only.
