### PR TITLE
Use bundled Bundler on ruby-head in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,10 @@ jobs:
             rubyopt: "--enable-frozen-string-literal"
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      # Released Bundler is broken on ruby-head due to ruby/ruby#16895.
+      # Use Ruby's bundled Bundler until rubygems/rubygems#9529 is released.
+      BUNDLER_VERSION: ${{ case(matrix.ruby == 'head', '0', '') }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby


### PR DESCRIPTION
Released Bundler is broken on ruby-head due to ruby/ruby#16895.
The fix (rubygems/rubygems#9529) has not been released yet.
