### PR TITLE
Bump version to v0.32.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 PATH
   remote: .
   specs:
-    typeprof (0.31.1)
+    typeprof (0.32.0)
       prism (>= 1.4.0)
       rbs (>= 3.6.0)
 

--- a/lib/typeprof/version.rb
+++ b/lib/typeprof/version.rb
@@ -1,3 +1,3 @@
 module TypeProf
-  VERSION = "0.31.1"
+  VERSION = "0.32.0"
 end


### PR DESCRIPTION
## Summary

Let's release version v0.32.0. :tada:

Full Changelog is https://github.com/ruby/typeprof/compare/v0.31.1...19ff60cf3360e39488bff70183df28d621259c77

## Changes

The notes included in the GitHub Release are as follows:

```bash
$ gh api repos/ruby/typeprof/releases/generate-notes \
  -f tag_name=v0.32.0 \
  -f previous_tag_name=v0.31.1 \
  -f target_commitish=master \
  --jq .body
```

```
## What's Changed
* Support default type declaration for a type parameter by @mame in https://github.com/ruby/typeprof/pull/359
* Fix crash in break in loop by @mame in https://github.com/ruby/typeprof/pull/365
* Add RBS type definition file jump to typeDefinition LSP feature by @S-H-GAMELINKS in https://github.com/ruby/typeprof/pull/357
* Fix RBS::ParsingError when block argument is assigned to rest keywords hash by @sinsoku in https://github.com/ruby/typeprof/pull/358
* Manage the types of RBS keyword args as Array instead of Hash by @mame in https://github.com/ruby/typeprof/pull/366
* Add timeout-minutes to CI workflow by @sinsoku in https://github.com/ruby/typeprof/pull/364
* Improve Record type inference for hash literals by @sinsoku in https://github.com/ruby/typeprof/pull/360
* Fix infinite loop when block has multiple params for sort_by etc by @pvcresin in https://github.com/ruby/typeprof/pull/367
* Fix hover on method parameters with inline RBS annotations by @whtsht in https://github.com/ruby/typeprof/pull/369
* Fix keyword-as-hash handling for methods without keyword params by @pvcresin in https://github.com/ruby/typeprof/pull/372
* Format constant declarations relative to their enclosing scope by @pvcresin in https://github.com/ruby/typeprof/pull/371
* Fix fcall include handling with context-aware meta parsing by @pvcresin in https://github.com/ruby/typeprof/pull/370
* Add --exclude option to skip files matching glob patterns by @sinsoku in https://github.com/ruby/typeprof/pull/368
* Skip allocating depended_* arrays for non-Box ChangeSets by @pvcresin in https://github.com/ruby/typeprof/pull/374
* Ensure tests pass even in a LANG=C environment by @mame in https://github.com/ruby/typeprof/pull/378
* Bundle update by @mame in https://github.com/ruby/typeprof/pull/379
* Add --show-stats option (for experiment) by @mame in https://github.com/ruby/typeprof/pull/380
* Track method(:sym) objects by @mame in https://github.com/ruby/typeprof/pull/381
* Fix missing ClassVariableWriteNode.new by @mame in https://github.com/ruby/typeprof/pull/382
* Wrong offset for opt positionals by @mame in https://github.com/ruby/typeprof/pull/383
* Fix TypeError for rest_positionals/rest_keywords in method signature … by @mame in https://github.com/ruby/typeprof/pull/384
* Cache UTF-16 code unit column by @mame in https://github.com/ruby/typeprof/pull/385
* Allow raise unknown by @mame in https://github.com/ruby/typeprof/pull/386
* Optimization by @mame in https://github.com/ruby/typeprof/pull/387
* Analyze RBS files before RB files for better type inference by @sinsoku in https://github.com/ruby/typeprof/pull/375
* Use Array#partition by @mame in https://github.com/ruby/typeprof/pull/388
* Skip bot type in typecheck to fix false errors on return/next by @mame in https://github.com/ruby/typeprof/pull/389
* Remove ad-hoc "untyped" guard from wrong_return_type by @mame in https://github.com/ruby/typeprof/pull/390
* Optimization by @mame in https://github.com/ruby/typeprof/pull/391
* Fix superclass resolution for `class Foo < Foo` and add circular inheritance diagnostic by @mame in https://github.com/ruby/typeprof/pull/392
* Skip overload resolution when positional arguments have no type information by @mame in https://github.com/ruby/typeprof/pull/393
* Use relative class/module names in RBS output by @mame in https://github.com/ruby/typeprof/pull/394
* Add builtin support for Kernel#send, __send__, and public_send by @mame in https://github.com/ruby/typeprof/pull/397
* Skip overload resolution when splat arguments have uninformative elem… by @mame in https://github.com/ruby/typeprof/pull/398
* Improve for node by @mame in https://github.com/ruby/typeprof/pull/399
* Fix constant resolution to prioritize nesting scope over Object ancestors by @sinsoku in https://github.com/ruby/typeprof/pull/395
* Fix --port option not being passed to LSP socket server by @sinsoku in https://github.com/ruby/typeprof/pull/396
* Support splat arguments in Kernel#send builtin by @mame in https://github.com/ruby/typeprof/pull/400
* Fix overload oscillation for generic type arguments, tuples, and hashes by @mame in https://github.com/ruby/typeprof/pull/401
* Extend marker DSL by @mame in https://github.com/ruby/typeprof/pull/402
* Fix type inference for multiple assignment of generic Array[T] by @sekito1107 in https://github.com/ruby/typeprof/pull/403
* Add test for multi-argument break in blocks by @mame in https://github.com/ruby/typeprof/pull/405
* Support block optional parameters and destructing parameters by @mame in https://github.com/ruby/typeprof/pull/406
* Move passing known-issues to proper scenario directories by @mame in https://github.com/ruby/typeprof/pull/404
* Use nested hashes for edge storage in ChangeSet by @mame in https://github.com/ruby/typeprof/pull/407
* Keyword overload resolution by @mame in https://github.com/ruby/typeprof/pull/409
* Notify StaticReads when constant values are defined or removed by @mame in https://github.com/ruby/typeprof/pull/411
* Extract OverloadSet class to cache overload comparison results by @mame in https://github.com/ruby/typeprof/pull/412
* Add builtin type inference for `Kernel#Array` by @sekito1107 in https://github.com/ruby/typeprof/pull/410
* Fix superclass path rendering to add :: prefix when needed by @pvcresin in https://github.com/ruby/typeprof/pull/413
* Add # typeprof:ignore comment to suppress diagnostics by @mame in https://github.com/ruby/typeprof/pull/417
* Handle Array slice assignment (ary[start, len] = val) in builtin by @mame in https://github.com/ruby/typeprof/pull/418
* Add module_function support by @mame in https://github.com/ruby/typeprof/pull/419
* Add attr_writer support by @mame in https://github.com/ruby/typeprof/pull/420
* Splat fallback by @mame in https://github.com/ruby/typeprof/pull/421
* Prioritize RBS ivar declarations over inferred types on read by @mame in https://github.com/ruby/typeprof/pull/422
* Isolate variable types across case/when branches by @mame in https://github.com/ruby/typeprof/pull/423
* Fix BotFilter to restore types when base exits bot-only state by @mame in https://github.com/ruby/typeprof/pull/424
* Fix optional type typecheck to accept nil by @mame in https://github.com/ruby/typeprof/pull/425
* Include Hash::_Key interface in Object for correct key? typecheck by @mame in https://github.com/ruby/typeprof/pull/426
* Support .nil? narrowing for local and instance variables by @mame in https://github.com/ruby/typeprof/pull/427
* Support narrowing for if (y = x) assignment in condition by @mame in https://github.com/ruby/typeprof/pull/428
* Support forwarded arguments in calls, super, and nested blocks by @pvcresin in https://github.com/ruby/typeprof/pull/416
* Fix NoMethodError in AST diff for record types by @mame in https://github.com/ruby/typeprof/pull/432
* Fix infinite loop in `define_all` for RBS include with same-name nested constant by @sinsoku in https://github.com/ruby/typeprof/pull/437
* Add Struct.new and Data.define support by @mame in https://github.com/ruby/typeprof/pull/438
* Fix NoMethodError in SigTySingletonNode#show due to uninitialized @args by @sinsoku in https://github.com/ruby/typeprof/pull/430
* Lazily initialize ChangeSet collections to reduce GC pressure by @sinsoku in https://github.com/ruby/typeprof/pull/433
* Lazily initialize BasicVertex and MethodEntity to reduce GC pressure by @sinsoku in https://github.com/ruby/typeprof/pull/435
* Add report guide for writing scenario files by @sinsoku in https://github.com/ruby/typeprof/pull/439
* Add known issues scenarios by @pvcresin in https://github.com/ruby/typeprof/pull/440
* Fix crash on empty parentheses () in AST conversion by @ahogappa in https://github.com/ruby/typeprof/pull/441
* Support LSP 3.17 `positionEncoding` negotiation by @ahogappa in https://github.com/ruby/typeprof/pull/442
* Fix RuntimeError on `()` as a method arg or hash splat value by @mame in https://github.com/ruby/typeprof/pull/445
* Support `class Foo = Bar` / `module Foo = Bar` declarations in RBS by @rhiroe in https://github.com/ruby/typeprof/pull/444
* Fix NoMethodError in CallBaseNode#modified_vars for anonymous rest by @sinsoku in https://github.com/ruby/typeprof/pull/447
* Enable bundler cache in GitHub Actions by @sinsoku in https://github.com/ruby/typeprof/pull/450
* Use bundled Bundler on ruby-head in CI by @sinsoku in https://github.com/ruby/typeprof/pull/455
* Set up release automation via Trusted Publisher by @sinsoku in https://github.com/ruby/typeprof/pull/453
* Skip directories ending with `.rb` when collecting analysis targets by @sinsoku in https://github.com/ruby/typeprof/pull/454

## New Contributors
* @whtsht made their first contribution in https://github.com/ruby/typeprof/pull/369
* @sekito1107 made their first contribution in https://github.com/ruby/typeprof/pull/403
* @rhiroe made their first contribution in https://github.com/ruby/typeprof/pull/444

**Full Changelog**: https://github.com/ruby/typeprof/compare/v0.31.1...v0.32.0
```
