### PR TITLE
Pass GH_TOKEN to gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,5 @@ jobs:
         run: |
           tag_name="$(git describe --tags --abbrev=0)"
           gh release create "${tag_name}" --verify-tag --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

`gh` CLI does not read the Actions token automatically.
It must be passed via the GH_TOKEN env var.


## Notes

This is the same fix as the example displayed by gh cli.

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable. Example:
  env:
    GH_TOKEN: ${{ github.token }}
```