### PR TITLE
Support `extend`

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -283,6 +283,8 @@ module TypeProf::Core
           case raw_node.name
           when :include
             return IncludeMetaNode.new(raw_node, lenv)
+          when :extend
+            return ExtendMetaNode.new(raw_node, lenv)
           when :attr_reader
             return AttrReaderMetaNode.new(raw_node, lenv)
           when :attr_writer
@@ -460,6 +462,7 @@ module TypeProf::Core
       when RBS::AST::Members::Prepend
         SigPrependNode.new(raw_decl, lenv)
       when RBS::AST::Members::Extend
+        SigExtendNode.new(raw_decl, lenv)
       when RBS::AST::Members::Public
       when RBS::AST::Members::Private
       when RBS::AST::Members::Alias

--- a/lib/typeprof/core/ast/meta.rb
+++ b/lib/typeprof/core/ast/meta.rb
@@ -46,6 +46,52 @@ module TypeProf::Core
       end
     end
 
+    class ExtendMetaNode < Node
+      def initialize(raw_node, lenv)
+        super(raw_node, lenv)
+        # TODO: error for splat
+        @args = raw_node.arguments.arguments.map do |raw_arg|
+          next if raw_arg.is_a?(Prism::SplatNode)
+          lenv.use_strict_const_scope do
+            AST.create_node(raw_arg, lenv)
+          end
+        end.compact
+        # TODO: error for non-LIT
+        # TODO: fine-grained hover
+      end
+
+      attr_reader :args
+
+      def subnodes = { args: }
+
+      def define0(genv)
+        mod = genv.resolve_cpath(@lenv.cref.cpath)
+        @args.each do |arg|
+          arg.define(genv)
+          if arg.static_ret
+            arg.static_ret.followers << mod
+            mod.add_extend_def(genv, arg)
+          end
+        end
+      end
+
+      def undefine0(genv)
+        mod = genv.resolve_cpath(@lenv.cref.cpath)
+        @args.each do |arg|
+          if arg.static_ret
+            mod.remove_extend_def(genv, arg)
+          end
+          arg.undefine(genv)
+        end
+        super(genv)
+      end
+
+      def install0(genv)
+        @args.each {|arg| arg.install(genv) }
+        Source.new
+      end
+    end
+
     class AttrReaderMetaNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)

--- a/lib/typeprof/core/ast/sig_decl.rb
+++ b/lib/typeprof/core/ast/sig_decl.rb
@@ -318,6 +318,55 @@ module TypeProf::Core
       end
     end
 
+    class SigExtendNode < Node
+      def initialize(raw_decl, lenv)
+        super(raw_decl, lenv)
+        name = raw_decl.name
+        @cpath = name.namespace.path + [name.name]
+        @toplevel = name.namespace.absolute?
+        @args = raw_decl.args.map {|arg| AST.create_rbs_type(arg, lenv) }
+      end
+
+      attr_reader :cpath, :toplevel, :args
+      def subnodes = { args: }
+      def attrs = { cpath:, toplevel: }
+
+      def define0(genv)
+        @args.each {|arg| arg.define(genv) }
+        const_reads = []
+        const_read = BaseConstRead.new(genv, @cpath.first, @toplevel ? CRef::Toplevel : @lenv.cref, true)
+        const_reads << const_read
+        @cpath[1..].each do |cname|
+          const_read = ScopedConstRead.new(cname, const_read, true)
+          const_reads << const_read
+        end
+        mod = genv.resolve_cpath(@lenv.cref.cpath)
+        const_read.followers << mod
+        mod.add_extend_decl(genv, self)
+        const_reads
+      end
+
+      def define_copy(genv)
+        mod = genv.resolve_cpath(@lenv.cref.cpath)
+        mod.add_extend_decl(genv, self)
+        mod.remove_extend_decl(genv, @prev_node)
+        super(genv)
+      end
+
+      def undefine0(genv)
+        mod = genv.resolve_cpath(@lenv.cref.cpath)
+        mod.remove_extend_decl(genv, self)
+        @static_ret.each do |const_read|
+          const_read.destroy(genv)
+        end
+        @args.each {|arg| arg.undefine(genv) }
+      end
+
+      def install0(genv)
+        Source.new
+      end
+    end
+
     class SigAliasNode < Node
       def initialize(raw_decl, lenv)
         super(raw_decl, lenv)

--- a/lib/typeprof/core/ast/sig_type.rb
+++ b/lib/typeprof/core/ast/sig_type.rb
@@ -23,6 +23,9 @@ module TypeProf::Core
           if f_mod.module?
             return true if typecheck_for_prepended_modules(genv, changes, ty, f_mod, f_args, subst)
             return true if typecheck_for_included_modules(genv, changes, ty, f_mod, f_args, subst)
+            if ty.is_a?(Type::Singleton)
+              return true if typecheck_for_extended_modules(genv, changes, ty, f_mod, f_args, subst)
+            end
           end
 
           ty = genv.get_superclass_type(ty, changes, {})
@@ -77,6 +80,32 @@ module TypeProf::Core
         changes.add_depended_superclass(inc_ty.mod)
 
         return true if typecheck_for_included_modules(genv, changes, inc_ty, f_mod, f_args, subst)
+      end
+      return false
+    end
+
+    def self.typecheck_for_extended_modules(genv, changes, a_ty, f_mod, f_args, subst)
+      a_ty.mod.extended_modules.each do |ext_decl, ext_mod|
+        if ext_decl.is_a?(AST::SigExtendNode) && ext_mod.type_params
+          ext_ty = genv.get_instance_type(ext_mod, ext_decl.args, changes, {}, a_ty)
+        else
+          type_params = ext_mod.type_params.map {|(_name, _default_ty)| Source.new() } # TODO: better support
+          ext_ty = Type::Instance.new(genv, ext_mod, type_params)
+        end
+        if ext_ty.mod == f_mod
+          args_all_match = true
+          f_args.zip(ext_ty.args) do |f_arg_node, a_arg_vtx|
+            unless f_arg_node.typecheck(genv, changes, a_arg_vtx, subst)
+              args_all_match = false
+              break
+            end
+          end
+          return true if args_all_match
+        end
+        changes.add_depended_superclass(ext_ty.mod)
+
+        # The extended module may itself include other modules
+        return true if typecheck_for_included_modules(genv, changes, ext_ty, f_mod, f_args, subst)
       end
       return false
     end

--- a/lib/typeprof/core/env.rb
+++ b/lib/typeprof/core/env.rb
@@ -80,7 +80,7 @@ module TypeProf::Core
         # TODO: prepended modules
         yield mod, singleton
         if singleton
-          # TODO: extended modules
+          each_extended_module(mod, &blk)
         else
           each_included_module(mod, &blk)
         end
@@ -92,6 +92,15 @@ module TypeProf::Core
       mod.included_modules.each do |_inc_decl, inc_mod|
         yield inc_mod, false
         each_included_module(inc_mod, &blk)
+      end
+    end
+
+    def each_extended_module(mod, &blk)
+      # An extended module contributes its instance methods (singleton = false)
+      # as the receiver's singleton methods.
+      mod.extended_modules.each do |_ext_decl, ext_mod|
+        yield ext_mod, false
+        each_included_module(ext_mod, &blk)
       end
     end
 

--- a/lib/typeprof/core/env/module_entity.rb
+++ b/lib/typeprof/core/env/module_entity.rb
@@ -9,6 +9,8 @@ module TypeProf::Core
       @include_defs = Set.empty
       @prepend_decls = []
       @prepend_defs = []
+      @extend_decls = Set.empty
+      @extend_defs = Set.empty
 
       # `class Foo = Bar` / `module Foo = Bar` declarations attached to this entity.
       # Maps an alias decl to the target ModuleEntity at the time of registration.
@@ -23,6 +25,7 @@ module TypeProf::Core
       @self_types = {}
       @included_modules = {}
       @prepended_modules = {}
+      @extended_modules = {}
       @basic_object = @cpath == [:BasicObject]
 
       # child modules (subclasses and all modules that include me)
@@ -57,6 +60,7 @@ module TypeProf::Core
     attr_reader :self_types
     attr_reader :included_modules
     attr_reader :prepended_modules
+    attr_reader :extended_modules
     attr_reader :child_modules
 
     attr_reader :superclass_type_args
@@ -216,6 +220,26 @@ module TypeProf::Core
 
     def remove_include_def(genv, node)
       @include_defs.delete(node) || raise
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def add_extend_decl(genv, node)
+      @extend_decls << node
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def remove_extend_decl(genv, node)
+      @extend_decls.delete(node) || raise
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def add_extend_def(genv, node)
+      @extend_defs << node
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def remove_extend_def(genv, node)
+      @extend_defs.delete(node) || raise
       genv.add_static_eval_queue(:parent_modules_changed, self)
     end
 
@@ -396,6 +420,30 @@ module TypeProf::Core
           any_updated = true
         end
       end
+      @extend_decls.each do |edecl|
+        new_parent_cpath = edecl.static_ret.last.cpath
+        new_parent, updated = update_parent(genv, edecl, @extended_modules[edecl], new_parent_cpath)
+        if updated
+          if new_parent
+            @extended_modules[edecl] = new_parent
+          else
+            @extended_modules.delete(edecl) || raise
+          end
+          any_updated = true
+        end
+      end
+      @extend_defs.each do |edef|
+        new_parent_cpath = edef.static_ret ? edef.static_ret.cpath : nil
+        new_parent, updated = update_parent(genv, edef, @extended_modules[edef], new_parent_cpath)
+        if updated
+          if new_parent
+            @extended_modules[edef] = new_parent
+          else
+            @extended_modules.delete(edef) || raise
+          end
+          any_updated = true
+        end
+      end
       @included_modules.delete_if do |origin, old_mod|
         if @include_decls.include?(origin) || @include_defs.include?(origin)
           false
@@ -407,6 +455,15 @@ module TypeProf::Core
       end
       @prepended_modules.delete_if do |origin, old_mod|
         if @prepend_decls.include?(origin) || @prepend_defs.include?(origin)
+          false
+        else
+          _new_parent, updated = update_parent(genv, origin, old_mod, nil)
+          any_updated ||= updated
+          true
+        end
+      end
+      @extended_modules.delete_if do |origin, old_mod|
+        if @extend_decls.include?(origin) || @extend_defs.include?(origin)
           false
         else
           _new_parent, updated = update_parent(genv, origin, old_mod, nil)

--- a/lib/typeprof/core/env/module_entity.rb
+++ b/lib/typeprof/core/env/module_entity.rb
@@ -9,6 +9,8 @@ module TypeProf::Core
       @include_defs = Set.empty
       @prepend_decls = []
       @prepend_defs = []
+      @extend_decls = Set.empty
+      @extend_defs = Set.empty
 
       # `class Foo = Bar` / `module Foo = Bar` declarations attached to this entity.
       # Maps an alias decl to the target ModuleEntity at the time of registration.
@@ -23,6 +25,7 @@ module TypeProf::Core
       @self_types = {}
       @included_modules = {}
       @prepended_modules = {}
+      @extended_modules = {}
       @basic_object = @cpath == [:BasicObject]
 
       # child modules (subclasses and all modules that include me)
@@ -57,6 +60,7 @@ module TypeProf::Core
     attr_reader :self_types
     attr_reader :included_modules
     attr_reader :prepended_modules
+    attr_reader :extended_modules
     attr_reader :child_modules
 
     attr_reader :superclass_type_args
@@ -216,6 +220,26 @@ module TypeProf::Core
 
     def remove_include_def(genv, node)
       @include_defs.delete(node) || raise
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def add_extend_decl(genv, node)
+      @extend_decls << node
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def remove_extend_decl(genv, node)
+      @extend_decls.delete(node) || raise
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def add_extend_def(genv, node)
+      @extend_defs << node
+      genv.add_static_eval_queue(:parent_modules_changed, self)
+    end
+
+    def remove_extend_def(genv, node)
+      @extend_defs.delete(node) || raise
       genv.add_static_eval_queue(:parent_modules_changed, self)
     end
 
@@ -397,6 +421,30 @@ module TypeProf::Core
           any_updated = true
         end
       end
+      @extend_decls.each do |edecl|
+        new_parent_cpath = edecl.static_ret.last.cpath
+        new_parent, updated = update_parent(genv, edecl, @extended_modules[edecl], new_parent_cpath)
+        if updated
+          if new_parent
+            @extended_modules[edecl] = new_parent
+          else
+            @extended_modules.delete(edecl) || raise
+          end
+          any_updated = true
+        end
+      end
+      @extend_defs.each do |edef|
+        new_parent_cpath = edef.static_ret ? edef.static_ret.cpath : nil
+        new_parent, updated = update_parent(genv, edef, @extended_modules[edef], new_parent_cpath)
+        if updated
+          if new_parent
+            @extended_modules[edef] = new_parent
+          else
+            @extended_modules.delete(edef) || raise
+          end
+          any_updated = true
+        end
+      end
       @included_modules.delete_if do |origin, old_mod|
         if @include_decls.include?(origin) || @include_defs.include?(origin)
           false
@@ -408,6 +456,15 @@ module TypeProf::Core
       end
       @prepended_modules.delete_if do |origin, old_mod|
         if @prepend_decls.include?(origin) || @prepend_defs.include?(origin)
+          false
+        else
+          _new_parent, updated = update_parent(genv, origin, old_mod, nil)
+          any_updated ||= updated
+          true
+        end
+      end
+      @extended_modules.delete_if do |origin, old_mod|
+        if @extend_decls.include?(origin) || @extend_defs.include?(origin)
           false
         else
           _new_parent, updated = update_parent(genv, origin, old_mod, nil)

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -1158,7 +1158,10 @@ module TypeProf::Core
           skip = false
 
           if ty.is_a?(Type::Singleton)
-            # TODO: extended modules
+            # Check extended modules (their instance methods are singleton methods here)
+            break if resolve_extended_modules(genv, changes, base_ty_env, ty, mid) do |me, ty, mid|
+              yield me, ty, mid, orig_ty
+            end
           else
             # Finally check included modules
             break if resolve_included_modules(genv, changes, base_ty_env, ty, mid) do |me, ty, mid|
@@ -1253,6 +1256,38 @@ module TypeProf::Core
           yield me, inc_ty, mid
         else
           found ||= resolve_included_modules(genv, changes, base_ty_env, inc_ty, mid, &blk)
+        end
+      end
+      found
+    end
+
+    def resolve_extended_modules(genv, changes, base_ty_env, ty, mid, &blk)
+      found = false
+
+      alias_limit = 0
+      # An extended module's instance methods are resolved as the receiver's
+      # singleton methods, so look them up with singleton = false.
+      ty.mod.extended_modules.each do |ext_decl, ext_mod|
+        if ext_decl.is_a?(AST::SigExtendNode) && ext_mod.type_params
+          ext_ty = genv.get_instance_type(ext_mod, ext_decl.args, changes, base_ty_env, ty)
+        else
+          type_params = ext_mod.type_params.map { Source.new() } # TODO: better support
+          ext_ty = Type::Instance.new(genv, ext_mod, type_params)
+        end
+
+        me = ext_ty.mod.get_method(false, mid)
+        changes.add_depended_method_entity(me) if changes
+        if !me.aliases.empty?
+          mid = me.aliases.values.first
+          alias_limit += 1
+          redo if alias_limit < 5
+        end
+        if me.exist?
+          found = true
+          yield me, ext_ty, mid
+        else
+          # The extended module may itself include other modules.
+          found ||= resolve_included_modules(genv, changes, base_ty_env, ext_ty, mid, &blk)
         end
       end
       found

--- a/lib/typeprof/core/graph/box.rb
+++ b/lib/typeprof/core/graph/box.rb
@@ -1180,7 +1180,10 @@ module TypeProf::Core
           skip = false
 
           if ty.is_a?(Type::Singleton)
-            # TODO: extended modules
+            # Check extended modules (their instance methods are singleton methods here)
+            break if resolve_extended_modules(genv, changes, base_ty_env, ty, mid) do |me, ty, mid|
+              yield me, ty, mid, orig_ty
+            end
           else
             # Finally check included modules
             break if resolve_included_modules(genv, changes, base_ty_env, ty, mid) do |me, ty, mid|
@@ -1275,6 +1278,38 @@ module TypeProf::Core
           yield me, inc_ty, mid
         else
           found ||= resolve_included_modules(genv, changes, base_ty_env, inc_ty, mid, &blk)
+        end
+      end
+      found
+    end
+
+    def resolve_extended_modules(genv, changes, base_ty_env, ty, mid, &blk)
+      found = false
+
+      alias_limit = 0
+      # An extended module's instance methods are resolved as the receiver's
+      # singleton methods, so look them up with singleton = false.
+      ty.mod.extended_modules.each do |ext_decl, ext_mod|
+        if ext_decl.is_a?(AST::SigExtendNode) && ext_mod.type_params
+          ext_ty = genv.get_instance_type(ext_mod, ext_decl.args, changes, base_ty_env, ty)
+        else
+          type_params = ext_mod.type_params.map { Source.new() } # TODO: better support
+          ext_ty = Type::Instance.new(genv, ext_mod, type_params)
+        end
+
+        me = ext_ty.mod.get_method(false, mid)
+        changes.add_depended_method_entity(me) if changes
+        if !me.aliases.empty?
+          mid = me.aliases.values.first
+          alias_limit += 1
+          redo if alias_limit < 5
+        end
+        if me.exist?
+          found = true
+          yield me, ext_ty, mid
+        else
+          # The extended module may itself include other modules.
+          found ||= resolve_included_modules(genv, changes, base_ty_env, ext_ty, mid, &blk)
         end
       end
       found

--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -497,6 +497,11 @@ module TypeProf::Core
                   out << "  " * stack.size + "include #{ inc_mod.show_cpath }"
                 end
               end
+              mod.extended_modules.each do |ext_def, ext_mod|
+                if ext_def.is_a?(AST::ConstantReadNode) && ext_def.lenv.path == path
+                  out << "  " * stack.size + "extend #{ ext_mod.show_cpath }"
+                end
+              end
               # Output method definitions from meta nodes (StructNewNode etc.)
               node.boxes(:mdef) do |mdef|
                 out << "  " * stack.size + "def #{ mdef.singleton ? "self." : "" }#{ mdef.mid }: " + mdef.show(@options[:output_parameter_names])

--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -503,6 +503,11 @@ module TypeProf::Core
                   out << "  " * stack.size + "include #{ inc_mod.show_cpath }"
                 end
               end
+              mod.extended_modules.each do |ext_def, ext_mod|
+                if ext_def.is_a?(AST::ConstantReadNode) && ext_def.lenv.path == path
+                  out << "  " * stack.size + "extend #{ ext_mod.show_cpath }"
+                end
+              end
               # Output method definitions from meta nodes (StructNewNode etc.)
               node.boxes(:mdef) do |mdef|
                 # A user-written method overrides the generated one

--- a/scenario/incremental/extend.rb
+++ b/scenario/incremental/extend.rb
@@ -1,0 +1,40 @@
+## update
+module Helpers
+  def shout(s) = s.upcase
+end
+
+class App
+end
+
+App.shout("hi")
+
+## assert
+module Helpers
+  def shout: (untyped) -> untyped
+end
+class App
+end
+
+## diagnostics
+(8,4)-(8,9): undefined method: singleton(App)#shout
+
+## update
+module Helpers
+  def shout(s) = s.upcase
+end
+
+class App
+  extend Helpers
+end
+
+App.shout("hi")
+
+## assert
+module Helpers
+  def shout: (String) -> String
+end
+class App
+  extend Helpers
+end
+
+## diagnostics

--- a/scenario/incremental/remove-extend.rb
+++ b/scenario/incremental/remove-extend.rb
@@ -1,0 +1,30 @@
+## update: test0.rb
+module Helpers
+  def shout(s) = s.upcase
+end
+
+App.shout("hi")
+
+## update: test1.rb
+class App
+  extend Helpers
+end
+
+## assert: test0.rb
+module Helpers
+  def shout: (String) -> String
+end
+
+## diagnostics: test0.rb
+
+## update: test1.rb
+class App
+end
+
+## assert: test0.rb
+module Helpers
+  def shout: (untyped) -> untyped
+end
+
+## diagnostics: test0.rb
+(5,4)-(5,9): undefined method: singleton(App)#shout

--- a/scenario/rbs/extend-module-arg.rb
+++ b/scenario/rbs/extend-module-arg.rb
@@ -1,0 +1,24 @@
+## update: test.rbs
+module Helpers
+  def shout: (String) -> String
+end
+
+class App
+  extend Helpers
+end
+
+class Object
+  def takes_mod: (Helpers) -> String
+end
+
+## update: test.rb
+def check
+  takes_mod(App)
+end
+
+## assert: test.rb
+class Object
+  def check: -> String
+end
+
+## diagnostics: test.rb

--- a/scenario/rbs/extend.rb
+++ b/scenario/rbs/extend.rb
@@ -1,0 +1,19 @@
+## update: test.rbs
+module Helpers
+  def shout: (String) -> String
+end
+class App
+  extend Helpers
+end
+
+## update: test.rb
+def check
+  App.shout("hi")
+end
+
+## assert: test.rb
+class Object
+  def check: -> String
+end
+
+## diagnostics: test.rb


### PR DESCRIPTION
TypeProf did not handle `extend`, so methods added via `extend M` were reported as "undefined method" and `extend` was missing from the dumped RBS.

Implement it symmetrically to `include`: parse Ruby/RBS `extend`, resolve the extended module's instance methods as the receiver's singleton methods, and dump `extend` for class bodies (like `include`).

Self-referential `extend` (e.g. `extend self`) is still unsupported.