### PR TITLE
Support attr_reader/attr_writer/attr_accessor in singleton classes

### DIFF
--- a/lib/typeprof/core/ast/meta.rb
+++ b/lib/typeprof/core/ast/meta.rb
@@ -49,6 +49,7 @@ module TypeProf::Core
     class AttrReaderMetaNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
+        @singleton = lenv.cref.scope_level == :metaclass
         @args = []
         raw_node.arguments.arguments.each do |raw_arg|
           @args << raw_arg.value.to_sym if raw_arg.type == :symbol_node
@@ -57,9 +58,9 @@ module TypeProf::Core
         # TODO: fine-grained hover
       end
 
-      attr_reader :args
+      attr_reader :singleton, :args
 
-      def attrs = { args: }
+      def attrs = { singleton:, args: }
 
       def req_positionals = []
       def opt_positionals = []
@@ -78,9 +79,9 @@ module TypeProf::Core
       def install0(genv)
         @args.each do |arg|
           ivar_name = :"@#{ arg }"
-          ivar_box = @changes.add_ivar_read_box(genv, @lenv.cref.cpath, false, ivar_name)
+          ivar_box = @changes.add_ivar_read_box(genv, @lenv.cref.cpath, @singleton, ivar_name)
           ret_box = @changes.add_escape_box(genv, ivar_box.ret)
-          @changes.add_method_def_box(genv, @lenv.cref.cpath, false, arg, FormalArguments::Empty, [ret_box])
+          @changes.add_method_def_box(genv, @lenv.cref.cpath, @singleton, arg, FormalArguments::Empty, [ret_box])
         end
         Source.new
       end
@@ -89,15 +90,16 @@ module TypeProf::Core
     class AttrWriterMetaNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
+        @singleton = lenv.cref.scope_level == :metaclass
         @args = []
         raw_node.arguments.arguments.each do |raw_arg|
           @args << raw_arg.value.to_sym if raw_arg.type == :symbol_node
         end
       end
 
-      attr_reader :args
+      attr_reader :singleton, :args
 
-      def attrs = { args: }
+      def attrs = { singleton:, args: }
 
       def mname_code_range(name)
         idx = @args.index(name.to_sym)
@@ -107,7 +109,7 @@ module TypeProf::Core
 
       def define0(genv)
         @args.map do |arg|
-          mod = genv.resolve_ivar(lenv.cref.cpath, false, :"@#{ arg }")
+          mod = genv.resolve_ivar(lenv.cref.cpath, @singleton, :"@#{ arg }")
           mod.add_def(self)
           mod
         end
@@ -115,7 +117,7 @@ module TypeProf::Core
 
       def define_copy(genv)
         @args.map do |arg|
-          mod = genv.resolve_ivar(lenv.cref.cpath, false, :"@#{ arg }")
+          mod = genv.resolve_ivar(lenv.cref.cpath, @singleton, :"@#{ arg }")
           mod.add_def(self)
           mod.remove_def(@prev_node)
           mod
@@ -125,7 +127,7 @@ module TypeProf::Core
 
       def undefine0(genv)
         @args.each do |arg|
-          mod = genv.resolve_ivar(lenv.cref.cpath, false, :"@#{ arg }")
+          mod = genv.resolve_ivar(lenv.cref.cpath, @singleton, :"@#{ arg }")
           mod.remove_def(self)
         end
       end
@@ -136,7 +138,7 @@ module TypeProf::Core
           @changes.add_edge(genv, vtx, ive.vtx)
           ret_box = @changes.add_escape_box(genv, vtx)
           f_args = FormalArguments.new([vtx], [], nil, [], [], [], nil, nil)
-          @changes.add_method_def_box(genv, @lenv.cref.cpath, false, :"#{ arg }=", f_args, [ret_box])
+          @changes.add_method_def_box(genv, @lenv.cref.cpath, @singleton, :"#{ arg }=", f_args, [ret_box])
         end
         Source.new
       end
@@ -145,6 +147,7 @@ module TypeProf::Core
     class AttrAccessorMetaNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
+        @singleton = lenv.cref.scope_level == :metaclass
         @args = []
         raw_node.arguments.arguments.each do |raw_arg|
           @args << raw_arg.value.to_sym if raw_arg.type == :symbol_node
@@ -153,9 +156,9 @@ module TypeProf::Core
         # TODO: fine-grained hover
       end
 
-      attr_reader :args
+      attr_reader :singleton, :args
 
-      def attrs = { args: }
+      def attrs = { singleton:, args: }
 
       def mname_code_range(name)
         idx = @args.index(name.to_sym) # TODO: support string args
@@ -165,7 +168,7 @@ module TypeProf::Core
 
       def define0(genv)
         @args.map do |arg|
-          mod = genv.resolve_ivar(lenv.cref.cpath, false, :"@#{ arg }")
+          mod = genv.resolve_ivar(lenv.cref.cpath, @singleton, :"@#{ arg }")
           mod.add_def(self)
           mod
         end
@@ -173,7 +176,7 @@ module TypeProf::Core
 
       def define_copy(genv)
         @args.map do |arg|
-          mod = genv.resolve_ivar(lenv.cref.cpath, false, :"@#{ arg }")
+          mod = genv.resolve_ivar(lenv.cref.cpath, @singleton, :"@#{ arg }")
           mod.add_def(self)
           mod.remove_def(@prev_node)
           mod
@@ -183,21 +186,21 @@ module TypeProf::Core
 
       def undefine0(genv)
         @args.each do |arg|
-          mod = genv.resolve_ivar(lenv.cref.cpath, false, :"@#{ arg }")
+          mod = genv.resolve_ivar(lenv.cref.cpath, @singleton, :"@#{ arg }")
           mod.remove_def(self)
         end
       end
 
       def install0(genv)
         @args.zip(@static_ret) do |arg, ive|
-          ivar_box = @changes.add_ivar_read_box(genv, @lenv.cref.cpath, false, :"@#{ arg }")
+          ivar_box = @changes.add_ivar_read_box(genv, @lenv.cref.cpath, @singleton, :"@#{ arg }")
           ret_box = @changes.add_escape_box(genv, ivar_box.ret)
-          @changes.add_method_def_box(genv, @lenv.cref.cpath, false, arg, FormalArguments::Empty, [ret_box])
+          @changes.add_method_def_box(genv, @lenv.cref.cpath, @singleton, arg, FormalArguments::Empty, [ret_box])
 
           vtx = Vertex.new(self)
           @changes.add_edge(genv, vtx, ive.vtx)
           f_args = FormalArguments.new([vtx], [], nil, [], [], [], nil, nil)
-          @changes.add_method_def_box(genv, @lenv.cref.cpath, false, :"#{ arg }=", f_args, [ret_box])
+          @changes.add_method_def_box(genv, @lenv.cref.cpath, @singleton, :"#{ arg }=", f_args, [ret_box])
         end
         Source.new
       end

--- a/scenario/class/eigenclass-attr.rb
+++ b/scenario/class/eigenclass-attr.rb
@@ -29,3 +29,17 @@ class C
   def self.name: -> untyped
   def self.value=: (String) -> String
 end
+
+## update
+class << Time
+  attr_accessor :count
+end
+
+Time.count = 1
+Time.count
+
+## assert
+class Time
+  def self.count: -> Integer
+  def self.count=: (Integer) -> Integer
+end


### PR DESCRIPTION
## Summary

`attr_reader` / `attr_writer` / `attr_accessor` written inside a singleton class (`class << self`) were treated as instance methods:

```ruby
class C
  class << self
    attr_accessor :age
  end
end
```

was inferred as `def age` / `def age=` instead of `def self.age` / `def self.age=`.

## Changes

- Detect the metaclass scope in the three attr meta nodes — the same `lenv.cref.scope_level == :metaclass` check `DefNode` already uses — and define the accessors and their backing ivar on the singleton. This also covers `class << SomeConstant`.
- Promote `scenario/known-issues/eigenclass-attr.rb` to `scenario/class/`.

All 433 tests pass (`bundle exec rake test`).