### PR TITLE
Fix crash on anonymous splat in find pattern and `{**nil}`

### DIFF
--- a/lib/typeprof/core/ast/pattern.rb
+++ b/lib/typeprof/core/ast/pattern.rb
@@ -58,9 +58,9 @@ module TypeProf::Core
     class FindPatternNode < Node
       def initialize(raw_node, lenv)
         super(raw_node, lenv)
-        @left = raw_node.left ? AST.create_pattern_node(raw_node.left.expression, lenv) : nil
+        @left = raw_node.left.expression ? AST.create_pattern_node(raw_node.left.expression, lenv) : nil
         @requireds = raw_node.requireds.map {|raw_elem| AST.create_pattern_node(raw_elem, lenv) }
-        @right = raw_node.right ? AST.create_pattern_node(raw_node.right.expression, lenv) : nil
+        @right = raw_node.right.expression ? AST.create_pattern_node(raw_node.right.expression, lenv) : nil
       end
 
       attr_reader :left, :requireds, :right

--- a/lib/typeprof/core/ast/pattern.rb
+++ b/lib/typeprof/core/ast/pattern.rb
@@ -39,7 +39,14 @@ module TypeProf::Core
         @keys = raw_node.elements.map {|raw_assoc| raw_assoc.key.value.to_sym }
         @values = raw_node.elements.map {|raw_assoc| AST.create_pattern_node(raw_assoc.value, lenv) }
         @rest = !!raw_node.rest
-        @rest_pattern = raw_node.rest && raw_node.rest.value ? AST.create_pattern_node(raw_node.rest.value, lenv) : nil
+        @rest_pattern = case raw_node.rest
+                        when Prism::AssocSplatNode
+                          AST.create_pattern_node(raw_node.rest.value, lenv) if raw_node.rest.value
+                        when Prism::NoKeywordsParameterNode, nil
+                          nil
+                        else
+                          raise
+                        end
       end
 
       attr_reader :keys, :values, :rest, :rest_pattern

--- a/scenario/patterns/find_pat.rb
+++ b/scenario/patterns/find_pat.rb
@@ -5,6 +5,12 @@ def check(x)
     :foo
   in *a, String, *b
     :bar # TODO: this should be excluded
+  in [*, Integer, *b]
+    :anon_left
+  in [*a, Integer, *]
+    :anon_right
+  in [*, Integer, *]
+    :anon_both
   else
     :zzz
   end
@@ -14,5 +20,5 @@ check([1].to_a)
 
 ## assert
 class Object
-  def check: (Array[Integer]) -> (:bar | :foo | :zzz)
+  def check: (Array[Integer]) -> (:anon_both | :anon_left | :anon_right | :bar | :foo | :zzz)
 end

--- a/scenario/patterns/hash_pat.rb
+++ b/scenario/patterns/hash_pat.rb
@@ -12,6 +12,8 @@ def check(x)
     :baz
   in MyHash[a: Integer]
     :qux
+  in { **nil }
+    :no_kw
   else
     :zzz
   end
@@ -23,5 +25,5 @@ check({ a: 42 })
 class MyHash
 end
 class Object
-  def check: ({ a: Integer }) -> (:bar | :baz | :foo | :qux | :zzz)
+  def check: ({ a: Integer }) -> (:bar | :baz | :foo | :no_kw | :qux | :zzz)
 end


### PR DESCRIPTION
Two pattern-matching forms crash during AST construction on master:

```ruby
case ary
in [*, x, *rest]
  x
end
# => lib/typeprof/core/ast.rb:334:in 'create_pattern_node':
#    undefined method 'type' for nil (NoMethodError)
```

```ruby
case h
in {**nil}
  1
end
# => lib/typeprof/core/ast/pattern.rb:42:in 'initialize':
#    undefined method 'value' for an instance of Prism::NoKeywordsParameterNode
```

Prism represents an anonymous splat as a `SplatNode` whose `expression` is `nil`, and `HashPatternNode#rest` can be a `NoKeywordsParameterNode`, which has no `value`. Both were passed to `AST.create_pattern_node` unchecked. `ArrayPatternNode` already guards against these, so this applies the same handling to `FindPatternNode` and `HashPatternNode`.