### PR TITLE
Hide the auto-generated Struct initialize when the block defines its own

### DIFF
--- a/lib/typeprof/core/ast/meta.rb
+++ b/lib/typeprof/core/ast/meta.rb
@@ -253,6 +253,22 @@ module TypeProf::Core
       def subnodes = { block_body: }
       def attrs = { static_cpath:, members:, kind: }
 
+      # A method written in the block body (e.g. a custom initialize)
+      # overrides the auto-generated one, which should then be hidden
+      # from the RBS output.
+      def block_defines_method?(singleton, mid)
+        return false unless @block_body
+        found = false
+        @block_body.traverse do |event, node|
+          if event == :enter && node.is_a?(DefNode) &&
+             node.singleton == singleton && node.mid == mid &&
+             node.lenv.cref.cpath == @static_cpath
+            found = true
+          end
+        end
+        found
+      end
+
       # Interface expected by MethodDefBox
       def req_positionals = @kind == :struct ? @members : []
       def opt_positionals = []

--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -499,6 +499,7 @@ module TypeProf::Core
               end
               # Output method definitions from meta nodes (StructNewNode etc.)
               node.boxes(:mdef) do |mdef|
+                next if node.is_a?(AST::StructNewNode) && node.block_defines_method?(mdef.singleton, mdef.mid)
                 out << "  " * stack.size + "def #{ mdef.singleton ? "self." : "" }#{ mdef.mid }: " + mdef.show(@options[:output_parameter_names])
               end
             else

--- a/scenario/misc/struct_new.rb
+++ b/scenario/misc/struct_new.rb
@@ -69,3 +69,25 @@ class Baz
   def set_label: -> String
   def ivar: -> String
 end
+
+## update
+# https://github.com/ruby/typeprof/issues/458
+# A user-defined initialize in the block overrides the auto-generated one,
+# so the RBS output must contain only the user-defined signature.
+Pt = Struct.new(:x, :y) do
+  def initialize(x = 0, y = 0)
+    super
+  end
+end
+Pt.new
+Pt.new(3, 4)
+
+## assert
+class Pt
+  def x: -> Integer
+  def x=: (untyped) -> untyped
+  def y: -> Integer
+  def y=: (untyped) -> untyped
+  def self.[]: (Integer, Integer) -> Pt
+  def initialize: (?Integer, ?Integer) -> void
+end


### PR DESCRIPTION
## Summary

Fixes #458.

`Struct.new(:x, :y) do def initialize(x = 0, y = 0); super; end end` emitted
two `def initialize:` lines — the auto-generated `(Integer, Integer) -> void`
and the user-defined `(?Integer, ?Integer) -> void` — so the generated RBS
fails `rbs validate` with `RBS::DuplicatedMethodDefinitionError`.

A method defined in the block body overrides the auto-generated one, so
`dump_declarations` now skips a `StructNewNode`-synthesized entry when the
block body defines a method with the same name (checked via a new
`StructNewNode#block_defines_method?`, which ignores defs belonging to nested
classes inside the block). The guard also covers block overrides of member
readers/writers, and `Data.define` shares the same path.

The synthesized method box itself stays installed: `super` in the user's
`initialize` resolves to the untyped stdlib `Struct#initialize`, and the
synthesized box is what carries `Pt.new(3, 4)` argument types into the member
ivars, so removing it would degrade `def x: -> Integer` to untyped.

One limitation left as is: `def self.[]` keeps the member-based signature
rather than mirroring the user-defined `initialize` (the issue's expected
output shows the mirrored form). That needs `[]` to reuse the user
`initialize`'s formal arguments and looks like a separate inference
improvement.

## Changes

- `lib/typeprof/core/ast/meta.rb`: add `StructNewNode#block_defines_method?`
- `lib/typeprof/core/service.rb`: skip shadowed synthesized method entries in
  `dump_declarations`
- `scenario/misc/struct_new.rb`: regression scenario from the issue repro
  (fails before the fix with exactly the duplicated line from the report)

## Testing

- `bundle exec ruby test/scenario_test.rb -n "/struct_new/"`
- `bundle exec rake test` (433 tests, 830 assertions, 0 failures)
- `rbs -I out.rbs validate` on the output generated from the issue's script
  now exits 0