### PR TITLE
Fix crash when calling attr_* methods with keyword arguments

### DIFF
--- a/lib/typeprof/core/ast/meta.rb
+++ b/lib/typeprof/core/ast/meta.rb
@@ -69,6 +69,7 @@ module TypeProf::Core
       def req_keywords = []
       def opt_keywords = []
       def rest_keywords = nil
+      def no_keywords = false
 
       def mname_code_range(name)
         idx = @args.index(name.to_sym) # TODO: support string args
@@ -100,6 +101,12 @@ module TypeProf::Core
       attr_reader :singleton, :args
 
       def attrs = { singleton:, args: }
+
+      # Interface expected by MethodDefBox
+      def req_keywords = []
+      def opt_keywords = []
+      def rest_keywords = nil
+      def no_keywords = false
 
       def mname_code_range(name)
         idx = @args.index(name.to_sym)
@@ -159,6 +166,12 @@ module TypeProf::Core
       attr_reader :singleton, :args
 
       def attrs = { singleton:, args: }
+
+      # Interface expected by MethodDefBox
+      def req_keywords = []
+      def opt_keywords = []
+      def rest_keywords = nil
+      def no_keywords = false
 
       def mname_code_range(name)
         idx = @args.index(name.to_sym) # TODO: support string args

--- a/scenario/meta/attr_kwargs.rb
+++ b/scenario/meta/attr_kwargs.rb
@@ -1,0 +1,23 @@
+## update
+class Foo
+  attr_reader :a
+  attr_accessor :b
+  attr_writer :c
+  alias set_c c=
+end
+foo = Foo.new
+foo.a(k: 1)
+foo.b(k: 1)
+foo.set_c(k: 1)
+
+## assert
+class Foo
+  def a: -> untyped
+  def b: -> untyped
+  def b=: (untyped) -> untyped
+  def c=: ({ k: Integer }) -> { k: Integer }
+end
+
+## diagnostics
+(8,4)-(8,5): wrong number of arguments (1 for 0)
+(9,4)-(9,5): wrong number of arguments (1 for 0)


### PR DESCRIPTION
`MethodDefBox#normalize_keyword_hash_argument_for_def` expects the keyword interface on the method definition node, which the attr_* meta nodes did not fully implement. So `attr_reader :foo` plus `x.foo(k: 1)` crashed with `NoMethodError`.

Now the keywords are packed into a hash argument, as for any method without keyword parameters.
