### PR TITLE
Add a regression test for re-analyzing an array pattern

### DIFF
--- a/scenario/patterns/array_pat_reedit.rb
+++ b/scenario/patterns/array_pat_reedit.rb
@@ -1,0 +1,27 @@
+## update
+def foo(ary)
+  case ary
+  in [a]
+    a
+  end
+end
+foo([1])
+
+## assert
+class Object
+  def foo: ([Integer]) -> Integer
+end
+
+## update
+def foo(ary)
+  case ary
+  in [a]
+    a.to_s
+  end
+end
+foo([1])
+
+## assert
+class Object
+  def foo: ([Integer]) -> String
+end


### PR DESCRIPTION
`ArrayPatternNode` used to return `@posts`, an Array, from install, so the invariant check in `update_rb_file` raised `RuntimeError: []` the second time a file containing an array pattern was analyzed. f6a6e65c fixed it as a side effect; nothing covered it.