### PR TITLE
Bump version to v0.33.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    typeprof (0.32.0)
+    typeprof (0.33.0)
       prism (>= 1.4.0)
       rbs (>= 3.6.0)
 

--- a/lib/typeprof/version.rb
+++ b/lib/typeprof/version.rb
@@ -1,3 +1,3 @@
 module TypeProf
-  VERSION = "0.32.0"
+  VERSION = "0.33.0"
 end


### PR DESCRIPTION
## Summary

Let's release v0.33.0.

**Full Changelog**: https://github.com/ruby/typeprof/compare/v0.32.0...62c7d8d9cd6d407d8e62c8b685d3866dff6e7749

## Content of the release notes to be generated

```
## What's Changed
* Pass GH_TOKEN to gh release create by @sinsoku in https://github.com/ruby/typeprof/pull/457
* Support Symbol#to_proc block inference by @pvcresin in https://github.com/ruby/typeprof/pull/452
* Fix crash on empty block parameters `||` and `|; x|` by @sinsoku in https://github.com/ruby/typeprof/pull/451
* Lazily convert Prism/RBS locations to CodeRange objects by @sinsoku in https://github.com/ruby/typeprof/pull/436
* Merge duplicate constant declarations into a union type by @pvcresin in https://github.com/ruby/typeprof/pull/461
* Support attr_reader/attr_writer/attr_accessor in singleton classes by @pvcresin in https://github.com/ruby/typeprof/pull/463
* Fix crash on anonymous splat in find pattern and `{**nil}` by @ahogappa in https://github.com/ruby/typeprof/pull/465
* Support RBS 4.2 by @mame in https://github.com/ruby/typeprof/pull/468
* Fix crash when calling attr_* methods with keyword arguments by @sinsoku in https://github.com/ruby/typeprof/pull/469
* Fix splat fallback for union types by @pvcresin in https://github.com/ruby/typeprof/pull/467
* Rename `fallback` to `unresolved_recv` by @mame in https://github.com/ruby/typeprof/pull/470
* Hide the auto-generated Struct initialize when the block defines its own by @sjh9714 in https://github.com/ruby/typeprof/pull/466
* Struct intermediate class by @mame in https://github.com/ruby/typeprof/pull/471
* Support type inference for pattern-matching capture variables by @pvcresin in https://github.com/ruby/typeprof/pull/464
* Add a regression test for re-analyzing an array pattern by @mame in https://github.com/ruby/typeprof/pull/472
* Support `extend` by @sinsoku in https://github.com/ruby/typeprof/pull/462
* Guard against an include/extend cycle in on_ancestors_updated by @mame in https://github.com/ruby/typeprof/pull/473
* Handle mixed and omitted forwarded arguments by @pvcresin in https://github.com/ruby/typeprof/pull/434
* Forwarding keyword merge by @mame in https://github.com/ruby/typeprof/pull/474
* Add a benchmark workflow for real-world projects by @sinsoku in https://github.com/ruby/typeprof/pull/449

## New Contributors
* @sjh9714 made their first contribution in https://github.com/ruby/typeprof/pull/466

**Full Changelog**: https://github.com/ruby/typeprof/compare/v0.32.0...v0.33.0
```

<details><summary>Executed command</summary>

```bash
$ gh api repos/ruby/typeprof/releases/generate-notes \
  -f tag_name=v0.33.0 \
  -f previous_tag_name=v0.32.0 \
  -f target_commitish=master \
  --jq .body
```

</details>
