### PR TITLE
Accept a Prism::ParseResult as input in place of Ruby source text

### DIFF
--- a/lib/typeprof/core/ast.rb
+++ b/lib/typeprof/core/ast.rb
@@ -1,14 +1,24 @@
 module TypeProf::Core
   class AST
     def self.parse_rb(path, src, position_encoding)
-      result = Prism.parse(src)
+      build_rb(path, Prism.parse(src), position_encoding)
+    end
+
+    # This needs the comments and the Prism::Source, which a ParseResult has but a
+    # node does not.
+    def self.build_rb(path, result, position_encoding)
+      unless result.is_a?(Prism::ParseResult)
+        raise ArgumentError, "expected Prism::ParseResult, got #{ result.class }"
+      end
 
       return nil unless result.errors.empty?
 
       # comments, errors, magic_comments
       raw_scope = result.value
 
-      raise unless raw_scope.type == :program_node
+      unless raw_scope.is_a?(Prism::ProgramNode)
+        raise ArgumentError, "expected Prism::ProgramNode, got #{ raw_scope.class }"
+      end
 
       prism_source = result.source
       file_context = FileContext.new(path, position_encoding, prism_source, result.comments)

--- a/lib/typeprof/core/service.rb
+++ b/lib/typeprof/core/service.rb
@@ -55,10 +55,15 @@ module TypeProf::Core
     end
 
     def update_rb_file(path, code)
+      code = File.read(path) unless code
+      update_rb_ast(path, Prism.parse(code))
+    end
+
+    # path is used only as a key to find the previous analysis; the file is not read.
+    def update_rb_ast(path, parse_result)
       prev_node = @rb_text_nodes[path]
 
-      code = File.read(path) unless code
-      node = AST.parse_rb(path, code, @options[:position_encoding])
+      node = AST.build_rb(path, parse_result, @options[:position_encoding])
       return false unless node
 
       node.diff(@rb_text_nodes[path]) if prev_node

--- a/sig/typeprof.rbs
+++ b/sig/typeprof.rbs
@@ -12,6 +12,7 @@ module TypeProf
       def initialize: (Hash[untyped, untyped]) -> void
       def update_file: (String, String?) -> bool
       def update_rb_file: (String, String?) -> bool
+      def update_rb_ast: (String, Prism::ParseResult) -> bool
       def update_rbs_file: (String, String?) -> bool
       def definitions: (String, CodePosition) -> Array[untyped]
       def type_definitions: (String, CodePosition) -> Array[untyped]

--- a/test/core/ast_input_test.rb
+++ b/test/core/ast_input_test.rb
@@ -1,0 +1,69 @@
+require_relative "../helper"
+
+module TypeProf::Core
+  class ASTInputTest < Test::Unit::TestCase
+    def dump(service, path)
+      service.dump_declarations(path)
+    end
+
+    def test_update_rb_ast_matches_update_rb_file
+      src = "def foo(x) = x + 1\nfoo(1)\n"
+
+      from_text = TypeProf::Core::Service.new({})
+      from_text.update_rb_file("t.rb", src)
+
+      from_ast = TypeProf::Core::Service.new({})
+      assert_true(from_ast.update_rb_ast("t.rb", Prism.parse(src)))
+
+      assert_equal(dump(from_text, "t.rb"), dump(from_ast, "t.rb"))
+      assert_match(/def foo: \(Integer\) -> Integer/, dump(from_ast, "t.rb"))
+    end
+
+    def test_update_rb_ast_replaces_previous_analysis
+      service = TypeProf::Core::Service.new({})
+      service.update_rb_file("t.rb", "def foo = 1\n")
+      assert_match(/def foo: -> Integer/, dump(service, "t.rb"))
+
+      service.update_rb_ast("t.rb", Prism.parse("def foo = \"str\"\n"))
+      assert_match(/def foo: -> String/, dump(service, "t.rb"))
+      assert_not_match(/Integer/, dump(service, "t.rb"))
+    end
+
+    def test_update_rb_ast_keeps_comments
+      src = <<~RUBY
+        #: (String) -> Integer
+        def foo(x) = x.size
+
+        def bar
+          foo(1) # typeprof:ignore
+        end
+      RUBY
+      service = TypeProf::Core::Service.new({})
+      service.update_rb_ast("t.rb", Prism.parse(src))
+
+      assert_match(/def foo: \(String\) -> Integer/, dump(service, "t.rb"))
+      diags = []
+      service.diagnostics("t.rb") {|d| diags << d }
+      assert_empty(diags)
+    end
+
+    def test_update_rb_ast_with_syntax_error_returns_false
+      service = TypeProf::Core::Service.new({})
+      assert_false(service.update_rb_ast("t.rb", Prism.parse("def foo(\n")))
+    end
+
+    def test_update_rb_ast_rejects_non_parse_result
+      service = TypeProf::Core::Service.new({})
+      assert_raise(ArgumentError) { service.update_rb_ast("t.rb", Prism.parse("1").value) }
+      assert_raise(ArgumentError) { service.update_rb_ast("t.rb", "1") }
+    end
+
+    def test_update_rb_ast_honors_position_encoding
+      service = TypeProf::Core::Service.new(position_encoding: Encoding::UTF_8)
+      service.update_rb_ast("t.rb", Prism.parse("𐐀x = 1\n"))
+      node = service.instance_variable_get(:@rb_text_nodes)["t.rb"]
+      # "𐐀x = 1" ends at UTF-8 byte column 9 (4+1+1+1+1+1)
+      assert_equal(9, node.body.stmts.first.code_range.last.column)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Service#update_rb_ast(path, parse_result)`, which analyzes a Ruby file from a `Prism::ParseResult` the caller has already produced. `update_rb_file` now reads and parses, then delegates to it, so the two entry points share the same diff/replace path. `path` plays the same role as before: it is the key the analysis is stored under, and re-submitting the same path replaces the previous analysis.

`AST.parse_rb` is split so the `Prism.parse` call is separate from building the `ProgramNode` (`AST.build_rb`).

## Why a ParseResult and not a node

Comments (`#:` annotations, `typeprof:ignore`) and the `Prism::Source` used for position encoding are only reachable from the `ParseResult`; `Prism::Location#source` is not public. A bare node or a string is rejected with `ArgumentError`.

## Motivation

Tools that embed TypeProf and already walk the Prism tree for their own purposes currently have to hand TypeProf the source text and let it parse a second time. This lets them pass the tree they hold.

## Tests

`test/core/ast_input_test.rb`: parity with `update_rb_file`, replacement on re-submission, comments preserved, syntax error returns `false`, wrong argument types, position encoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
